### PR TITLE
feat: show file path tooltip on sidebar hover

### DIFF
--- a/internal/frontend/src/components/Sidebar.tsx
+++ b/internal/frontend/src/components/Sidebar.tsx
@@ -79,7 +79,7 @@ export function Sidebar({
                 : "bg-transparent text-gh-text-secondary hover:bg-gh-bg-hover"
             }`}
             onClick={() => onFileSelect(f.id)}
-            title={f.name}
+            title={f.path}
           >
             <svg className="size-4 shrink-0" viewBox="0 0 16 16" fill="currentColor">
               <path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z" />

--- a/internal/frontend/src/hooks/useApi.ts
+++ b/internal/frontend/src/hooks/useApi.ts
@@ -1,6 +1,7 @@
 export interface FileEntry {
   name: string;
   id: number;
+  path: string;
 }
 
 export interface Group {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,7 +19,7 @@ import (
 type FileEntry struct {
 	Name string `json:"name"`
 	ID   int    `json:"id"`
-	Path string `json:"-"`
+	Path string `json:"path"`
 }
 
 type Group struct {


### PR DESCRIPTION
## Summary
- Expose `FileEntry.Path` in the API response (previously hidden with `json:"-"`)
- Show full file path as a tooltip when hovering over file names in the sidebar

<img width="654" height="450" alt="CleanShot 2026-02-27 at 9  59 41@2x" src="https://github.com/user-attachments/assets/041f11a1-0635-468f-8232-21ccc1b6910a" />
