### PR TITLE
refactor: improve donegroup usage for graceful shutdown

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -13,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/mo/internal/static"
 )
 
@@ -40,7 +42,7 @@ type State struct {
 	watcher     *fsnotify.Watcher
 }
 
-func NewState() *State {
+func NewState(ctx context.Context) *State {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Printf("warning: failed to create file watcher: %v", err)
@@ -54,7 +56,10 @@ func NewState() *State {
 	}
 
 	if w != nil {
-		go s.watchLoop()
+		donegroup.Go(ctx, func() error {
+			s.watchLoop()
+			return nil
+		})
 	}
 
 	return s


### PR DESCRIPTION
## Summary
- Use `donegroup.Go` to manage `watchLoop` goroutine lifecycle, ensuring `Wait` guarantees its completion on shutdown
- Pass a timeout context to `srv.Shutdown` instead of `context.Background()` to prevent indefinite blocking
- Move `donegroup.WithCancel` before `NewState` so the donegroup context is available for goroutine management

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] Run `mo testdata/basic.md`, edit the file, verify live-reload works, then Ctrl+C and confirm clean shutdown