### PR TITLE
refactor: replace log and fmt.Fprintf(os.Stderr) with slog

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,8 +21,14 @@ THE SOFTWARE.
 */
 package main
 
-import "github.com/k1LoW/mo/cmd"
+import (
+	"log/slog"
+	"os"
+
+	"github.com/k1LoW/mo/cmd"
+)
 
 func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
 	cmd.Execute()
 }


### PR DESCRIPTION
## Summary
- Initialize `slog` with `slog.NewJSONHandler` in `main.go`
- Convert all `fmt.Fprintf(os.Stderr, ...)` in `cmd/root.go` to structured `slog` calls
- Convert all `log.Printf`/`log.Fatalf` in `internal/server/server.go` to structured `slog` calls
- Use appropriate log levels: `Info` for operational messages, `Warn` for non-fatal issues, `Error` for failures

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] Run `mo testdata/basic.md` and verify JSON log output on stderr