### PR TITLE
fix: reject directory paths passed as file arguments

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -110,8 +110,10 @@ func resolveFiles(args []string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("cannot resolve path %s: %w", arg, err)
 		}
-		if _, err := os.Stat(absPath); err != nil {
+		if stat, err := os.Stat(absPath); err != nil {
 			return nil, fmt.Errorf("file not found: %s", absPath)
+		} else if stat.IsDir() {
+			return nil, fmt.Errorf("%s is a directory", absPath)
 		}
 		files = append(files, absPath)
 	}


### PR DESCRIPTION
## Summary

Adds validation to reject directory paths when passed as CLI arguments, preventing confusing downstream errors (like below screenshot) when a user accidentally passes a directory instead of a file.

<img width="550" height="180" alt="image" src="https://github.com/user-attachments/assets/dacc9892-c838-4bb6-9d68-33d034b07e70" />
