### PR TITLE
feat: add table of contents right panel

### DIFF
--- a/internal/frontend/package.json
+++ b/internal/frontend/package.json
@@ -28,6 +28,7 @@
     "react-markdown": "^10.1.0",
     "rehype-github-alerts": "^4.2.0",
     "rehype-raw": "^7.0.0",
+    "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.0.0"
   },

--- a/internal/frontend/pnpm-lock.yaml
+++ b/internal/frontend/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1223,6 +1226,9 @@ packages:
     resolution: {integrity: sha512-tmT5sY+zvg2302XLYEfH2mtkViIM1SWf2nvYoF5N1ZsO0V6B2qZTiw3GOzw4vpjLygK/KG35qRlPFweHqfzz5w==}
     engines: {node: '>=10'}
 
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -1243,6 +1249,9 @@ packages:
 
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
 
   hast-util-is-element@3.0.0:
     resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
@@ -1733,6 +1742,9 @@ packages:
 
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -3179,6 +3191,8 @@ snapshots:
 
   github-markdown-css@5.9.0: {}
 
+  github-slugger@2.0.0: {}
+
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
@@ -3213,6 +3227,10 @@ snapshots:
       vfile: 6.0.3
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
+
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hast-util-is-element@3.0.0:
     dependencies:
@@ -3972,6 +3990,14 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-raw: 9.1.0
       vfile: 6.0.3
+
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.1.0
 
   remark-gfm@4.0.1:
     dependencies:

--- a/internal/frontend/src/components/TocPanel.tsx
+++ b/internal/frontend/src/components/TocPanel.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface TocHeading {
+  id: string;
+  text: string;
+  level: number;
+}
+
+interface TocPanelProps {
+  headings: TocHeading[];
+  activeHeadingId: string | null;
+  onHeadingClick: (id: string) => void;
+}
+
+const MIN_WIDTH = 180;
+const MAX_WIDTH = 480;
+const DEFAULT_WIDTH = 240;
+const STORAGE_KEY = "mo-toc-width";
+
+function getInitialWidth(): number {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    const n = parseInt(stored, 10);
+    if (n >= MIN_WIDTH && n <= MAX_WIDTH) return n;
+  }
+  return DEFAULT_WIDTH;
+}
+
+const INDENT: Record<number, string> = {
+  1: "pl-3",
+  2: "pl-3",
+  3: "pl-6",
+  4: "pl-9",
+  5: "pl-12",
+  6: "pl-15",
+};
+
+export function TocPanel({ headings, activeHeadingId, onHeadingClick }: TocPanelProps) {
+  const [width, setWidth] = useState(getInitialWidth);
+  const dragging = useRef(false);
+
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    dragging.current = true;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, []);
+
+  useEffect(() => {
+    const onMouseMove = (e: MouseEvent) => {
+      if (!dragging.current) return;
+      const clamped = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, window.innerWidth - e.clientX));
+      setWidth(clamped);
+    };
+    const onMouseUp = () => {
+      if (!dragging.current) return;
+      dragging.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+    return () => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    };
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, String(width));
+  }, [width]);
+
+  return (
+    <aside
+      className="relative shrink-0 bg-gh-bg-sidebar border-l border-gh-border flex flex-col overflow-y-auto"
+      style={{ width }}
+    >
+      {/* Resize handle */}
+      <div
+        className="absolute top-0 left-0 w-1 h-full cursor-col-resize hover:bg-gh-border active:bg-gh-border transition-colors"
+        onMouseDown={onMouseDown}
+      />
+      <nav className="flex flex-col pb-1">
+        {headings.length === 0 ? (
+          <div className="px-3 py-2 text-gh-text-secondary text-sm">
+            No headings
+          </div>
+        ) : (
+          headings.map((h) => (
+            <button
+              key={h.id}
+              className={`flex items-center w-full ${INDENT[h.level] ?? "pl-3"} pr-3 py-1.5 border-none cursor-pointer text-left text-sm transition-colors duration-150 ${
+                h.id === activeHeadingId
+                  ? "bg-gh-bg-active text-gh-text font-semibold"
+                  : "bg-transparent text-gh-text-secondary hover:bg-gh-bg-hover"
+              }`}
+              onClick={() => onHeadingClick(h.id)}
+              title={h.text}
+            >
+              <span className="overflow-hidden text-ellipsis whitespace-nowrap">
+                {h.text}
+              </span>
+            </button>
+          ))
+        )}
+      </nav>
+    </aside>
+  );
+}

--- a/internal/frontend/src/components/TocToggle.tsx
+++ b/internal/frontend/src/components/TocToggle.tsx
@@ -1,0 +1,18 @@
+interface TocToggleProps {
+  isTocOpen: boolean;
+  onToggle: () => void;
+}
+
+export function TocToggle({ isTocOpen, onToggle }: TocToggleProps) {
+  return (
+    <button
+      className="flex items-center justify-center bg-transparent border border-gh-border rounded-md p-1.5 text-gh-text-secondary cursor-pointer transition-colors duration-150 hover:bg-gh-bg-hover"
+      onClick={onToggle}
+      title={isTocOpen ? "Hide table of contents" : "Show table of contents"}
+    >
+      <svg className="size-5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 6.75h12M8.25 12h12M8.25 17.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+      </svg>
+    </button>
+  );
+}

--- a/internal/frontend/src/hooks/useActiveHeading.ts
+++ b/internal/frontend/src/hooks/useActiveHeading.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+
+export function useActiveHeading(
+  headingIds: string[],
+  scrollContainer: HTMLElement | null,
+): string | null {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!scrollContainer || headingIds.length === 0) {
+      setActiveId(null);
+      return;
+    }
+
+    const elements = headingIds
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => el !== null);
+
+    if (elements.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const intersecting = new Set<string>();
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            intersecting.add(entry.target.id);
+          }
+        }
+
+        // Find the topmost intersecting heading (in document order)
+        for (const id of headingIds) {
+          if (intersecting.has(id)) {
+            setActiveId(id);
+            return;
+          }
+        }
+      },
+      {
+        root: scrollContainer,
+        rootMargin: "0px 0px -80% 0px",
+      },
+    );
+
+    for (const el of elements) {
+      observer.observe(el);
+    }
+
+    return () => observer.disconnect();
+  }, [headingIds, scrollContainer]);
+
+  return activeId;
+}


### PR DESCRIPTION
## Summary
- Add a resizable ToC right panel that displays markdown headings with indentation by level
- Click a heading to smooth-scroll to its position in the document
- Active heading is highlighted based on scroll position (IntersectionObserver)
- Uses `rehype-slug` for automatic GitHub-style heading ID generation
- ToC panel width is resizable and persisted to localStorage