### PR TITLE
fix: resolve render loop caused by unstable references in ToC integration

### DIFF
--- a/internal/frontend/src/App.tsx
+++ b/internal/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Sidebar } from "./components/Sidebar";
 import { MarkdownViewer } from "./components/MarkdownViewer";
 import { ThemeToggle } from "./components/ThemeToggle";
@@ -113,12 +113,14 @@ export function App() {
     window.history.pushState(null, "", url);
   };
 
-  const handleFileOpened = (fileId: number) => {
+  const handleFileOpened = useCallback((fileId: number) => {
     setActiveFileId(fileId);
-  };
+  }, []);
+
+  const headingIds = useMemo(() => headings.map((h) => h.id), [headings]);
 
   const activeHeadingId = useActiveHeading(
-    headings.map((h) => h.id),
+    headingIds,
     scrollContainerRef.current,
   );
 

--- a/internal/frontend/src/components/MarkdownViewer.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.tsx
@@ -338,11 +338,13 @@ export function MarkdownViewer({ fileId, revision, onFileOpened, onHeadingsChang
     );
   }, [content, isRawView, components]);
 
+  const prevHeadingsKey = useRef("");
   useEffect(() => {
-    if (isRawView) {
-      onHeadingsChange([]);
-    } else {
-      onHeadingsChange([...headingsRef.current]);
+    const newHeadings = isRawView ? [] : [...headingsRef.current];
+    const key = newHeadings.map((h) => `${h.id}:${h.level}`).join(",");
+    if (key !== prevHeadingsKey.current) {
+      prevHeadingsKey.current = key;
+      onHeadingsChange(newHeadings);
     }
   }, [content, isRawView, onHeadingsChange, renderedContent]);
 


### PR DESCRIPTION
## Summary

- Wrap `handleFileOpened` in `useCallback` to stabilize `handleLinkClick` → `components` → `renderedContent` dependency chain
- Memoize `headingIds` array passed to `useActiveHeading` to prevent IntersectionObserver recreation on every render
- Add deduplication guard in headings useEffect to skip `onHeadingsChange` when headings haven't actually changed

These three unstable references created an infinite render loop introduced in #24 (ToC feature), which prevented Mermaid diagrams and Shiki syntax highlighting from completing their async rendering.
