### PR TITLE
feat: add copy buttons to Mermaid blocks

### DIFF
--- a/internal/frontend/src/components/MarkdownViewer.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.tsx
@@ -117,7 +117,8 @@ export function MermaidBlock({ code }: { code: string }) {
     return (
       <div className="relative group">
         <div dangerouslySetInnerHTML={{ __html: svg }} />
-        <CodeBlockCopyButton code={code} />
+        <MermaidImageCopyButton svg={svg} />
+        <CodeBlockCopyButton code={code} themed />
       </div>
     );
   }
@@ -131,7 +132,117 @@ export function MermaidBlock({ code }: { code: string }) {
   );
 }
 
-function CodeBlockCopyButton({ code }: { code: string }) {
+function MermaidImageCopyButton({ svg }: { svg: string }) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    try {
+      const blob = await svgToPngBlob(svg);
+      await navigator.clipboard.write([
+        new ClipboardItem({ "image/png": blob }),
+      ]);
+      setCopied(true);
+    } catch {
+      // clipboard API may fail in insecure contexts
+    }
+  };
+
+  return (
+    <button
+      className={`absolute right-10 top-2 flex items-center justify-center rounded-md p-1 cursor-pointer transition-all duration-150 border ${themedButtonStyle} ${copied ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
+      onClick={handleCopy}
+      title="Copy image"
+    >
+      {copied ? (
+        <svg className="size-4" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
+        </svg>
+      ) : (
+        <svg className="size-4" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M16 13.25A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25V2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75ZM1.75 2.5a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25Z" />
+          <path d="M0.5 12.75 4.5 5.5 7.5 9 9.5 6.5 15.5 12.75" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+function svgToPngBlob(svgString: string): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(svgString, "image/svg+xml");
+    const svgEl = doc.documentElement;
+
+    // Ensure xmlns is present for standalone SVG rendering
+    if (!svgEl.getAttribute("xmlns")) {
+      svgEl.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+    }
+
+    // Extract dimensions from the SVG element
+    const widthAttr = svgEl.getAttribute("width");
+    const heightAttr = svgEl.getAttribute("height");
+    const viewBox = svgEl.getAttribute("viewBox");
+
+    let width = 0;
+    let height = 0;
+
+    if (widthAttr && heightAttr) {
+      width = parseFloat(widthAttr);
+      height = parseFloat(heightAttr);
+    } else if (viewBox) {
+      const parts = viewBox.split(/[\s,]+/);
+      width = parseFloat(parts[2]);
+      height = parseFloat(parts[3]);
+    }
+
+    if (!width || !height) {
+      reject(new Error("Cannot determine SVG dimensions"));
+      return;
+    }
+
+    // Scale up for high-DPI displays
+    const scale = 4;
+    const serializer = new XMLSerializer();
+    const svgData = serializer.serializeToString(svgEl);
+    const dataUrl = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svgData);
+
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = width * scale;
+      canvas.height = height * scale;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("Failed to get canvas context"));
+        return;
+      }
+      ctx.scale(scale, scale);
+      ctx.drawImage(img, 0, 0, width, height);
+      canvas.toBlob((blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Failed to create PNG blob"));
+        }
+      }, "image/png");
+    };
+    img.onerror = () => {
+      reject(new Error("Failed to load SVG image"));
+    };
+    img.src = dataUrl;
+  });
+}
+
+const darkButtonStyle = "border-[#484f58] hover:border-[#8b949e] text-[#8b949e] bg-[#2d333b]";
+const themedButtonStyle = "border-gh-border hover:border-gh-text-secondary text-gh-text-secondary bg-gh-bg-secondary";
+
+function CodeBlockCopyButton({ code, themed = false }: { code: string; themed?: boolean }) {
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
@@ -149,9 +260,11 @@ function CodeBlockCopyButton({ code }: { code: string }) {
     }
   };
 
+  const colorStyle = themed ? themedButtonStyle : darkButtonStyle;
+
   return (
     <button
-      className={`absolute right-2 top-2 flex items-center justify-center rounded-md p-1 cursor-pointer transition-all duration-150 border border-[#484f58] hover:border-[#8b949e] ${copied ? "opacity-100 text-[#8b949e] bg-[#2d333b]" : "opacity-0 group-hover:opacity-100 text-[#8b949e] bg-[#2d333b]"}`}
+      className={`absolute right-2 top-2 flex items-center justify-center rounded-md p-1 cursor-pointer transition-all duration-150 border ${colorStyle} ${copied ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
       onClick={handleCopy}
       title="Copy code"
     >

--- a/internal/frontend/src/components/MermaidBlock.test.tsx
+++ b/internal/frontend/src/components/MermaidBlock.test.tsx
@@ -12,12 +12,14 @@ vi.mock("mermaid", () => ({
 import mermaid from "mermaid";
 
 const writeTextMock = vi.fn().mockResolvedValue(undefined);
+const writeMock = vi.fn().mockResolvedValue(undefined);
 
 beforeEach(() => {
   vi.clearAllMocks();
   writeTextMock.mockClear();
+  writeMock.mockClear();
   Object.defineProperty(navigator, "clipboard", {
-    value: { writeText: writeTextMock },
+    value: { writeText: writeTextMock, write: writeMock },
     writable: true,
     configurable: true,
   });
@@ -67,5 +69,113 @@ describe("MermaidBlock", () => {
     await waitFor(() => {
       expect(writeTextMock).toHaveBeenCalledWith("graph TD; A-->B");
     });
+  });
+
+  it("shows image copy button when mermaid renders successfully", async () => {
+    vi.mocked(mermaid.render).mockResolvedValue({
+      svg: "<svg>diagram</svg>",
+      bindFunctions: undefined,
+      diagramType: "flowchart",
+    });
+
+    render(<MermaidBlock code="graph TD; A-->B" />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Copy image")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show image copy button when rendering fails", async () => {
+    vi.mocked(mermaid.render).mockRejectedValue(new Error("parse error"));
+
+    render(<MermaidBlock code="invalid mermaid" />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Copy code")).toBeInTheDocument();
+    });
+    expect(screen.queryByTitle("Copy image")).not.toBeInTheDocument();
+  });
+
+  it("calls navigator.clipboard.write on image copy button click", async () => {
+    vi.mocked(mermaid.render).mockResolvedValue({
+      svg: '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">diagram</svg>',
+      bindFunctions: undefined,
+      diagramType: "flowchart",
+    });
+
+    // Mock URL.createObjectURL / revokeObjectURL (not available in jsdom)
+    URL.createObjectURL = vi.fn(() => "blob:mock-url");
+    URL.revokeObjectURL = vi.fn();
+
+    // Mock ClipboardItem (not available in jsdom)
+    const originalClipboardItem = globalThis.ClipboardItem;
+    vi.stubGlobal(
+      "ClipboardItem",
+      class MockClipboardItem {
+        types: string[];
+        items: Record<string, Blob>;
+        constructor(items: Record<string, Blob>) {
+          this.items = items;
+          this.types = Object.keys(items);
+        }
+        getType(type: string) {
+          return Promise.resolve(this.items[type]);
+        }
+      },
+    );
+
+    // Mock Image to trigger onload
+    const originalImage = globalThis.Image;
+    vi.stubGlobal(
+      "Image",
+      class MockImage {
+        naturalWidth = 100;
+        naturalHeight = 100;
+        onload: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        _src = "";
+        get src() {
+          return this._src;
+        }
+        set src(val: string) {
+          this._src = val;
+          setTimeout(() => this.onload?.(), 0);
+        }
+      },
+    );
+
+    // Mock canvas via createElement
+    const mockBlob = new Blob(["png"], { type: "image/png" });
+    const mockCtx = { drawImage: vi.fn(), scale: vi.fn() };
+    const origCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation(
+      (tag: string, options?: ElementCreationOptions) => {
+        if (tag === "canvas") {
+          return {
+            width: 0,
+            height: 0,
+            getContext: () => mockCtx,
+            toBlob: (cb: (b: Blob | null) => void) => cb(mockBlob),
+          } as unknown as HTMLCanvasElement;
+        }
+        return origCreateElement(tag, options);
+      },
+    );
+
+    render(<MermaidBlock code="graph TD; A-->B" />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Copy image")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTitle("Copy image"));
+
+    await waitFor(() => {
+      expect(writeMock).toHaveBeenCalledTimes(1);
+    });
+
+    globalThis.Image = originalImage;
+    globalThis.ClipboardItem = originalClipboardItem;
+    vi.mocked(document.createElement).mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- Add a code copy button to Mermaid blocks (copies the Mermaid source code)
- Add an image copy button that converts the rendered SVG diagram to a high-resolution PNG (4x scale) and copies it to the clipboard
- Mermaid block buttons use theme-aware styling so they look correct in both light and dark modes