### PR TITLE
feat: add Open in new tab to sidebar kebab menu

### DIFF
--- a/internal/frontend/src/App.tsx
+++ b/internal/frontend/src/App.tsx
@@ -9,7 +9,12 @@ import { useSSE } from "./hooks/useSSE";
 import { useActiveHeading } from "./hooks/useActiveHeading";
 import type { Group } from "./hooks/useApi";
 import { fetchGroups, removeFile } from "./hooks/useApi";
-import { allFileIds, parseGroupFromPath } from "./utils/groups";
+import {
+  allFileIds,
+  parseGroupFromPath,
+  parseFileIdFromSearch,
+  groupToPath,
+} from "./utils/groups";
 
 export function App() {
   const [groups, setGroups] = useState<Group[]>([]);
@@ -20,6 +25,9 @@ export function App() {
   const [headings, setHeadings] = useState<TocHeading[]>([]);
   const [contentRevision, setContentRevision] = useState(0);
   const knownFileIds = useRef<Set<number>>(new Set());
+  const initialFileId = useRef<number | null>(
+    parseFileIdFromSearch(window.location.search),
+  );
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const loadGroups = useCallback(async () => {
@@ -36,7 +44,7 @@ export function App() {
 
       setGroups(data);
 
-      if (added.length > 0) {
+      if (added.length > 0 && initialFileId.current == null) {
         // Only auto-select if the new file belongs to the current active group
         setActiveGroup((currentGroup) => {
           const group = data.find((g) => g.name === currentGroup);
@@ -72,6 +80,15 @@ export function App() {
     if (!group || group.files.length === 0) {
       setActiveFileId(null);
       return;
+    }
+    if (initialFileId.current != null) {
+      const requestedId = initialFileId.current;
+      initialFileId.current = null;
+      window.history.replaceState(null, "", groupToPath(activeGroup));
+      if (group.files.some((f) => f.id === requestedId)) {
+        setActiveFileId(requestedId);
+        return;
+      }
     }
     setActiveFileId((prev) => {
       const stillExists = group.files.some((f) => f.id === prev);
@@ -109,8 +126,7 @@ export function App() {
   const handleGroupChange = (name: string) => {
     setActiveGroup(name);
     setActiveFileId(null);
-    const url = name === "default" ? "/" : `/${name}`;
-    window.history.pushState(null, "", url);
+    window.history.pushState(null, "", groupToPath(name));
   };
 
   const handleFileOpened = useCallback((fileId: number) => {

--- a/internal/frontend/src/components/Sidebar.tsx
+++ b/internal/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Group } from "../hooks/useApi";
 import { removeFile } from "../hooks/useApi";
+import { buildFileUrl } from "../utils/groups";
+
+const MENU_ITEM_CLASS =
+  "w-full px-3 py-1.5 text-left text-sm bg-transparent border-none cursor-pointer text-gh-text-secondary hover:bg-gh-bg-hover hover:text-gh-text transition-colors duration-150 flex items-center gap-2";
 
 const MIN_WIDTH = 180;
 const MAX_WIDTH = 480;
@@ -79,6 +83,14 @@ export function Sidebar({
     return () => document.removeEventListener("mousedown", handleClick);
   }, [menuOpenId]);
 
+  const handleOpenInNewTab = useCallback(
+    (id: number) => {
+      setMenuOpenId(null);
+      window.open(buildFileUrl(activeGroup, id), "_blank");
+    },
+    [activeGroup],
+  );
+
   const handleRemove = useCallback((id: number) => {
     setMenuOpenId(null);
     removeFile(id);
@@ -123,10 +135,19 @@ export function Sidebar({
             {menuOpenId === f.id && (
               <div
                 ref={menuRef}
-                className="absolute right-0 top-full z-10 bg-gh-bg border border-gh-border rounded-md shadow-lg py-1 min-w-[120px]"
+                className="absolute right-0 top-full z-10 bg-gh-bg border border-gh-border rounded-md shadow-lg py-1 min-w-[160px]"
               >
                 <button
-                  className="w-full px-3 py-1.5 text-left text-sm bg-transparent border-none cursor-pointer text-gh-text-secondary hover:bg-gh-bg-hover hover:text-gh-text transition-colors duration-150 flex items-center gap-2"
+                  className={MENU_ITEM_CLASS}
+                  onClick={() => handleOpenInNewTab(f.id)}
+                >
+                  <svg className="size-4" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z" />
+                  </svg>
+                  Open in new tab
+                </button>
+                <button
+                  className={MENU_ITEM_CLASS}
                   onClick={() => handleRemove(f.id)}
                 >
                   <svg className="size-4" viewBox="0 0 16 16" fill="currentColor">

--- a/internal/frontend/src/utils/groups.test.ts
+++ b/internal/frontend/src/utils/groups.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { allFileIds, parseGroupFromPath } from "./groups";
+import {
+  allFileIds,
+  parseGroupFromPath,
+  groupToPath,
+  buildFileUrl,
+  parseFileIdFromSearch,
+} from "./groups";
 import type { Group } from "../hooks/useApi";
 
 describe("allFileIds", () => {
@@ -68,5 +74,55 @@ describe("parseGroupFromPath", () => {
 
   it("handles path without leading slash", () => {
     expect(parseGroupFromPath("notes")).toBe("notes");
+  });
+});
+
+describe("groupToPath", () => {
+  it("returns / for default group", () => {
+    expect(groupToPath("default")).toBe("/");
+  });
+
+  it("returns /name for named group", () => {
+    expect(groupToPath("design")).toBe("/design");
+  });
+});
+
+describe("buildFileUrl", () => {
+  it("builds URL for default group", () => {
+    expect(buildFileUrl("default", 1)).toBe("/?file=1");
+  });
+
+  it("builds URL for named group", () => {
+    expect(buildFileUrl("design", 5)).toBe("/design?file=5");
+  });
+});
+
+describe("parseFileIdFromSearch", () => {
+  it("returns null for empty search", () => {
+    expect(parseFileIdFromSearch("")).toBeNull();
+  });
+
+  it("parses file id from search string", () => {
+    expect(parseFileIdFromSearch("?file=2")).toBe(2);
+  });
+
+  it("returns null for non-numeric value", () => {
+    expect(parseFileIdFromSearch("?file=abc")).toBeNull();
+  });
+
+  it("returns null when file param is missing", () => {
+    expect(parseFileIdFromSearch("?other=1")).toBeNull();
+  });
+
+  it("handles search with multiple params", () => {
+    expect(parseFileIdFromSearch("?foo=bar&file=10&baz=1")).toBe(10);
+  });
+
+  it("returns null for zero", () => {
+    expect(parseFileIdFromSearch("?file=0")).toBeNull();
+  });
+
+  it("returns null for negative value", () => {
+    expect(parseFileIdFromSearch("?file=-3")).toBeNull();
   });
 });

--- a/internal/frontend/src/utils/groups.ts
+++ b/internal/frontend/src/utils/groups.ts
@@ -14,3 +14,19 @@ export function parseGroupFromPath(pathname: string): string {
   const path = pathname.replace(/^\//, "").replace(/\/$/, "");
   return path || "default";
 }
+
+export function groupToPath(groupName: string): string {
+  return groupName === "default" ? "/" : `/${groupName}`;
+}
+
+export function buildFileUrl(groupName: string, fileId: number): string {
+  return `${groupToPath(groupName)}?file=${fileId}`;
+}
+
+export function parseFileIdFromSearch(search: string): number | null {
+  const params = new URLSearchParams(search);
+  const raw = params.get("file");
+  if (raw == null) return null;
+  const id = parseInt(raw, 10);
+  return id > 0 ? id : null;
+}


### PR DESCRIPTION
## Summary
- Add "Open in new tab" option to the sidebar kebab menu, opening the selected file in a new browser tab via `?file={id}` query parameter
- Add `groupToPath`, `buildFileUrl`, and `parseFileIdFromSearch` utilities to `groups.ts` with tests
- Handle `?file=` query parameter in `App.tsx` for deep linking to a specific file on page load