### PR TITLE
Rename --close flag to --shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ The sidebar supports flat and tree view modes. Flat view shows file names only, 
 |------|------|
 | ![Flat view](images/sidebar-flat.png) | ![Tree view](images/sidebar-tree.png) |
 
-### Closing the server
+### Shutting down the server
 
-Use the `--close` flag to gracefully shut down a running `mo` server:
+Use the `--shutdown` flag to gracefully shut down a running `mo` server:
 
 ``` console
-$ mo --close            # Shut down the server on the default port
-$ mo --close -p 6276    # Shut down the server on a specific port
+$ mo --shutdown            # Shut down the server on the default port
+$ mo --shutdown -p 6276    # Shut down the server on a specific port
 ```
 
 ### Server restart
@@ -101,7 +101,7 @@ Click the restart button (bottom-right corner) to restart the `mo` server proces
 | `--port` | `-p` | `6275` | Server port |
 | `--open` | | | Always open browser |
 | `--no-open` | | | Never open browser |
-| `--close` | | | Shut down the running server |
+| `--shutdown` | | | Shut down the running server |
 
 ## Build
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ var (
 	open        bool
 	noOpen      bool
 	restore     string
-	closeServer bool
+	shutdownServer bool
 )
 
 var rootCmd = &cobra.Command{
@@ -95,7 +95,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&open, "open", false, "Always open browser (even when adding to existing group)")
 	rootCmd.Flags().BoolVar(&noOpen, "no-open", false, "Do not open browser automatically")
 	rootCmd.MarkFlagsMutuallyExclusive("open", "no-open")
-	rootCmd.Flags().BoolVar(&closeServer, "close", false, "Shut down the running mo server on the specified port")
+	rootCmd.Flags().BoolVar(&shutdownServer, "shutdown", false, "Shut down the running mo server on the specified port")
 	rootCmd.Flags().StringVar(&restore, "restore", "", "Restore state from file (internal use)")
 	rootCmd.Flags().MarkHidden("restore") //nolint:errcheck
 }
@@ -110,8 +110,8 @@ func run(cmd *cobra.Command, args []string) error {
 
 	addr := fmt.Sprintf("localhost:%d", port)
 
-	if closeServer {
-		return doClose(addr)
+	if shutdownServer {
+		return doShutdown(addr)
 	}
 
 	if restore != "" {
@@ -224,7 +224,7 @@ func tryAddToExisting(addr string, files []string) bool {
 	return true
 }
 
-func doClose(addr string) error {
+func doShutdown(addr string) error {
 	client := &http.Client{Timeout: 2 * time.Second}
 
 	resp, err := client.Get(fmt.Sprintf("http://%s/_/api/groups", addr))


### PR DESCRIPTION
## Summary
- Rename the `--close` CLI flag to `--shutdown` for better semantic clarity, aligning with common CLI conventions (`docker`, `systemctl`) and Go's `http.Server.Shutdown()` method