### PR TITLE
fix: handle atomic saves and improve live-reload reliability

### DIFF
--- a/internal/frontend/src/hooks/useSSE.ts
+++ b/internal/frontend/src/hooks/useSSE.ts
@@ -12,6 +12,8 @@ export function useSSE(callbacks: SSECallbacks) {
   useEffect(() => {
     let disposed = false;
     let es: EventSource | null = null;
+    let retryDelay = 1000;
+    const maxRetryDelay = 30000;
 
     function connect() {
       if (disposed) return;
@@ -31,10 +33,15 @@ export function useSSE(callbacks: SSECallbacks) {
         }
       });
 
+      es.onopen = () => {
+        retryDelay = 1000;
+      };
+
       es.onerror = () => {
         es?.close();
         if (!disposed) {
-          setTimeout(connect, 2000);
+          setTimeout(connect, retryDelay);
+          retryDelay = Math.min(retryDelay * 2, maxRetryDelay);
         }
       };
     }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/k1LoW/donegroup"
@@ -295,7 +296,7 @@ func (s *State) Subscribe() chan sseEvent {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	ch := make(chan sseEvent, 4)
+	ch := make(chan sseEvent, 16)
 	s.subscribers[ch] = struct{}{}
 	return ch
 }
@@ -383,21 +384,46 @@ func (s *State) watchLoop() {
 			if !ok {
 				return
 			}
-			if event.Has(fsnotify.Write) {
-				slog.Info("file changed", "path", event.Name)
-				ids := s.findIDsByPath(event.Name)
-				for _, id := range ids {
-					s.sendEvent(sseEvent{
-						Name: "file-changed",
-						Data: fmt.Sprintf(`{"id":%d}`, id),
-					})
-				}
+			ids := s.findIDsByPath(event.Name)
+			if len(ids) == 0 {
+				break
 			}
-		case _, ok := <-s.watcher.Errors:
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+				slog.Info("file changed", "path", event.Name)
+				s.notifyFileChanged(ids)
+			}
+			// Editors using atomic save (write-to-temp + rename) cause
+			// the original inode to disappear, which removes the watch.
+			// Re-add the watch so subsequent saves are still detected.
+			if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+				time.AfterFunc(100*time.Millisecond, func() {
+					if err := s.watcher.Add(event.Name); err != nil {
+						// File is actually gone — remove from file list
+						slog.Info("file deleted, removing from list", "path", event.Name)
+						for _, id := range ids {
+							s.RemoveFile(id)
+						}
+					} else {
+						slog.Info("re-watching file", "path", event.Name)
+						s.notifyFileChanged(ids)
+					}
+				})
+			}
+		case err, ok := <-s.watcher.Errors:
 			if !ok {
 				return
 			}
+			slog.Warn("file watcher error", "error", err)
 		}
+	}
+}
+
+func (s *State) notifyFileChanged(ids []int) {
+	for _, id := range ids {
+		s.sendEvent(sseEvent{
+			Name: "file-changed",
+			Data: fmt.Sprintf(`{"id":%d}`, id),
+		})
 	}
 }
 
@@ -421,6 +447,7 @@ func (s *State) sendEvent(e sseEvent) {
 		select {
 		case ch <- e:
 		default:
+			slog.Warn("SSE event dropped (subscriber buffer full)", "event", e.Name)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Watch for `Create`/`Remove`/`Rename` fsnotify events in addition to `Write` to support editors using atomic save (write-to-temp + rename pattern used by Vim, VS Code, etc.)
- Re-add file watcher after rename/remove to maintain watch on new inode; remove files from list when actually deleted
- Add exponential backoff (1s–30s cap) to SSE reconnection in `useSSE.ts`
- Increase SSE subscriber channel buffer from 4 to 16 and log warnings for dropped events and watcher errors