### PR TITLE
fix: avoid appending /default to URL when adding files to existing server

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -247,11 +247,8 @@ func tryAddToExisting(addr string, files []string) bool {
 	slog.Info("added files to existing server", "count", len(files), "addr", addr)
 	fmt.Fprintf(os.Stderr, "mo: added %d file(s) to http://%s\n", len(files), addr)
 
-	if !noOpen && (isNewGroup || open) {
-		url := fmt.Sprintf("http://%s/%s", addr, target)
-		if err := browser.OpenURL(url); err != nil {
-			slog.Warn("could not open browser", "error", err)
-		}
+	if isNewGroup || open {
+		openBrowser(addr)
 	}
 
 	return true


### PR DESCRIPTION
## Summary

- When adding files to an existing server via `mo test.md --open`, the browser URL incorrectly included `/default` for the default group (e.g., `http://localhost:6275/default` instead of `http://localhost:6275`)
- `tryAddToExisting` had its own URL-building logic that always appended the target group name. Replaced it with a call to `openBrowser()`, which already handles this correctly by skipping the path for the default group.