### PR TITLE
fix: render code blocks without language using Shiki and copy button

### DIFF
--- a/internal/frontend/src/components/MarkdownViewer.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.tsx
@@ -440,11 +440,15 @@ export function MarkdownViewer({ fileId, fileName, revision, onFileOpened, onHea
       code: ({ className, children, ...props }) => {
         const language = extractLanguage(className);
         const code = String(children).replace(/\n$/, "");
+        const isBlock = String(children).endsWith("\n");
         if (language) {
           if (language === "mermaid") {
             return <MermaidBlock code={code} />;
           }
           return <CodeBlock language={language} code={code} />;
+        }
+        if (isBlock) {
+          return <CodeBlock language="text" code={code} />;
         }
         return (
           <code className={className} {...props}>


### PR DESCRIPTION
## Summary

- Fenced code blocks without a language specifier (e.g. plain ` ``` `) were rendered as bare `<code>` elements, missing Shiki syntax highlighting and the copy button
- Detect block-level code by checking for a trailing newline (CommonMark guarantees this for fenced code blocks) and render them via `CodeBlock` with language `"text"`
- Inline code (single backtick) is unaffected

## Before / After

| Before | After |
|--------|-------|
| No syntax highlighting, no copy button | Shiki `text` highlighting + copy button |
| <img width="460" height="318" alt="CleanShot 2026-03-06 at 17 59 20" src="https://github.com/user-attachments/assets/727ec581-9711-40c0-8818-a8c7bb21447c" /> | <img width="460" height="318" alt="CleanShot 2026-03-06 at 17 59 39" src="https://github.com/user-attachments/assets/34995c76-1286-49bc-8b83-d097bcf9725b" /> |

## Test

Verified with a Markdown file containing both fenced code blocks with a language (e.g. ` ```yaml `, ` ```typescript `) and without (plain ` ``` `). Before this change, plain ` ``` ` blocks were rendered as bare `<code>` elements with no syntax highlighting or copy button. After, they render identically to language-specified blocks (Shiki highlighting + copy button).

Example input:

~~~md
```
repo/
  Dockerfile
  src/
    main.tsx
    App.tsx
    lib/
```

```ts
// server/index.ts
import Fastify from 'fastify'
import jwt from '@fastify/jwt'
import rateLimit from '@fastify/rate-limit'
```
~~~

Both blocks now render with consistent styling, syntax highlighting, and a copy button.


