### PR TITLE
fix: debounce watcher file change events

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -72,6 +72,7 @@ type State struct {
 	mu          sync.RWMutex
 	groups      map[string]*Group
 	subscribers map[chan sseEvent]struct{}
+	subMu       sync.RWMutex
 	watcher     *fsnotify.Watcher
 	restartCh   chan string
 	shutdownCh  chan struct{}
@@ -432,8 +433,8 @@ func (s *State) RemoveFile(id string) bool {
 }
 
 func (s *State) Subscribe() chan sseEvent {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.subMu.Lock()
+	defer s.subMu.Unlock()
 
 	ch := make(chan sseEvent, 16)
 	s.subscribers[ch] = struct{}{}
@@ -441,8 +442,8 @@ func (s *State) Subscribe() chan sseEvent {
 }
 
 func (s *State) Unsubscribe(ch chan sseEvent) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.subMu.Lock()
+	defer s.subMu.Unlock()
 
 	if _, ok := s.subscribers[ch]; ok {
 		delete(s.subscribers, ch)
@@ -456,10 +457,12 @@ func (s *State) CloseAllSubscribers() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.subMu.Lock()
 	for ch := range s.subscribers {
 		close(ch)
 		delete(s.subscribers, ch)
 	}
+	s.subMu.Unlock()
 
 	if s.watcher != nil {
 		s.watcher.Close()
@@ -928,6 +931,9 @@ func (s *State) handleDirMove(dirPath string) {
 }
 
 func (s *State) sendEvent(e sseEvent) {
+	s.subMu.RLock()
+	defer s.subMu.RUnlock()
+
 	for ch := range s.subscribers {
 		select {
 		case ch <- e:

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -923,6 +923,40 @@ func TestScheduleFileChanged_DebouncesDuplicateEvents(t *testing.T) {
 	}
 }
 
+func TestSendEvent_ConcurrentWithUnsubscribeDoesNotPanic(t *testing.T) {
+	s := newTestState(t)
+	ch := s.Subscribe()
+
+	done := make(chan struct{})
+	panicCh := make(chan any, 1)
+
+	go func() {
+		defer close(done)
+		defer func() {
+			if r := recover(); r != nil {
+				panicCh <- r
+			}
+		}()
+		for range 100 {
+			s.sendEvent(sseEvent{Name: eventFileChanged, Data: "{}"})
+		}
+	}()
+
+	for range 100 {
+		s.Unsubscribe(ch)
+		ch = s.Subscribe()
+	}
+	s.Unsubscribe(ch)
+
+	<-done
+
+	select {
+	case r := <-panicCh:
+		t.Fatalf("sendEvent panicked during concurrent unsubscribe: %v", r)
+	default:
+	}
+}
+
 // flushRecorder implements http.ResponseWriter and http.Flusher,
 // writing output to an io.Writer for streaming tests.
 type flushRecorder struct {


### PR DESCRIPTION
This pull request introduces a debouncing mechanism for file change events in the server, ensuring that rapid, repeated file changes are consolidated into a single notification. This prevents unnecessary duplicate events and improves system efficiency. The changes include new state fields, logic for debouncing, proper cleanup, and a unit test to verify the behavior.

**Debouncing file change events:**

* Added `fileChangeDebounce` and `fileChangeTimers` fields to the `State` struct, along with a default debounce duration constant (`defaultFileChangeDebounce`).
* Implemented the `scheduleFileChanged` method to debounce file change notifications, replacing direct calls to `notifyFileChanged`. This ensures only one notification is sent within the debounce window for each file. [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L787-R798) [[2]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L802-R813) [[3]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R833-R867)
* Modified the `State` constructor and test setup to initialize the new debounce fields. [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R104-R105) [[2]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92R39-R40)

**Resource cleanup:**

* Updated `CloseAllSubscribers` to stop and remove timers from `fileChangeTimers` to avoid resource leaks.

**Testing:**

* Added a unit test `TestScheduleFileChanged_DebouncesDuplicateEvents` to verify that duplicate file change events are properly debounced and only a single notification is sent.