### PR TITLE
refactor: apply modernize linter suggestions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - misspell
     - revive
     - funcorder
+    - modernize
   settings:
     errcheck:
       check-type-assertions: true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,12 +7,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -256,13 +258,9 @@ func run(cmd *cobra.Command, args []string) error {
 	target = resolved
 
 	if len(watchPatterns) > 0 && len(args) > 0 {
-		hasGlob := false
-		for _, p := range watchPatterns {
-			if hasGlobChars(p) {
-				hasGlob = true
-				break
-			}
-		}
+		hasGlob := slices.ContainsFunc(watchPatterns, func(p string) bool {
+			return hasGlobChars(p)
+		})
 		if !hasGlob {
 			return fmt.Errorf("cannot use --watch (-w) with file arguments\n(hint: the shell may have expanded the glob pattern; quote it to prevent expansion, e.g. -w '**/*.md')")
 		}
@@ -386,9 +384,7 @@ func filterValidRestoreData(rd *server.RestoreData) (map[string][]string, map[st
 	}
 
 	patternsByGroup := make(map[string][]string)
-	for group, patterns := range rd.Patterns {
-		patternsByGroup[group] = patterns
-	}
+	maps.Copy(patternsByGroup, rd.Patterns)
 
 	return filesByGroup, patternsByGroup, rd.UploadedFiles
 }
@@ -457,13 +453,7 @@ func tryAddToExisting(addr string, files []string, patterns []string) bool {
 		return false
 	}
 
-	isNewGroup := true
-	for _, g := range result.groups {
-		if g == target {
-			isNewGroup = false
-			break
-		}
-	}
+	isNewGroup := !slices.Contains(result.groups, target)
 
 	var deeplinks []deeplinkEntry
 	deeplinks = append(deeplinks, postFiles(result.client, addr, target, files)...)

--- a/internal/server/group.go
+++ b/internal/server/group.go
@@ -38,7 +38,7 @@ func validateGroupName(name string) error {
 		return fmt.Errorf("group name must not contain consecutive slashes")
 	}
 
-	for _, seg := range strings.Split(name, "/") {
+	for seg := range strings.SplitSeq(name, "/") {
 		if seg == "." || seg == ".." {
 			return fmt.Errorf("group name must not contain '.' or '..' path segments")
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -303,7 +303,7 @@ func TestHandleShutdown(t *testing.T) {
 		s := newTestState(t)
 		handler := NewHandler(s)
 
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			req := httptest.NewRequest("POST", "/_/api/shutdown", nil)
 			rec := httptest.NewRecorder()
 			handler.ServeHTTP(rec, req)
@@ -354,7 +354,7 @@ func TestHandleRestart(t *testing.T) {
 		}
 		handler := NewHandler(s)
 
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			req := httptest.NewRequest("POST", "/_/api/restart", nil)
 			rec := httptest.NewRecorder()
 			handler.ServeHTTP(rec, req)
@@ -848,12 +848,10 @@ func TestHandleSSE_StartedEvent(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/_/events", nil).WithContext(ctx)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		handler.ServeHTTP(rec, req)
 		pw.Close()
-	}()
+	})
 	t.Cleanup(func() {
 		cancel()
 		wg.Wait()


### PR DESCRIPTION
Use slices.Contains/ContainsFunc, maps.Copy, strings.SplitSeq, range-over-int, and WaitGroup.Go to satisfy golangci-lint modernize.