### PR TITLE
fix: update undici to 7.24.3 to resolve security vulnerabilities

### DIFF
--- a/internal/frontend/pnpm-lock.yaml
+++ b/internal/frontend/pnpm-lock.yaml
@@ -2439,8 +2439,8 @@ packages:
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.24.3:
+    resolution: {integrity: sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -4109,7 +4109,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.22.0
+      undici: 7.24.3
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5116,7 +5116,7 @@ snapshots:
 
   ufo@1.6.3: {}
 
-  undici@7.22.0: {}
+  undici@7.24.3: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## Summary
- Update `undici` from 7.22.0 to 7.24.3 to resolve all 6 open Dependabot security alerts
- Fixes: CRLF injection, unbounded memory consumption, HTTP request/response smuggling, WebSocket crashes