### PR TITLE
fix: prevent scroll chaining on content area

### DIFF
--- a/internal/frontend/src/App.tsx
+++ b/internal/frontend/src/App.tsx
@@ -344,7 +344,7 @@ export function App() {
           />
         )}
         <main className="flex-1 flex flex-col overflow-hidden">
-          <div ref={setScrollContainer} className="flex-1 overflow-y-auto p-8 bg-gh-bg">
+          <div ref={setScrollContainer} className="flex-1 overflow-y-auto overscroll-contain p-8 bg-gh-bg">
             {activeFileId != null ? (
               <MarkdownViewer
                 fileId={activeFileId}


### PR DESCRIPTION
## Description 

- Fix scroll chaining where scrolling past the end of the content area propagates to the
  parent (body), causing the entire page to scroll
- Add overscroll-behavior: contain to the scroll container to prevent scroll propagation

## Before

![CleanShot 2026-03-22 at 11 27 08](https://github.com/user-attachments/assets/04523758-a685-4459-a5b6-f5c0a0cc1b7d)

## After

![CleanShot 2026-03-22 at 11 25 07](https://github.com/user-attachments/assets/27698606-b684-43ff-a5f4-5ba2a4274d49)


Hi, @k1LoW ! Thank you for maintaining this project.
I noticed an issue with the scrolling behavior on macOS and created this PR to address it.
