### PR TITLE
[codex] Add content font size toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - <img src="images/icons/search.svg" width="16" height="16" alt="search"> Full-text search across file names and content
 - YAML frontmatter display (collapsible metadata block)
 - MDX file support (renders as Markdown, strips `import`/`export`, escapes JSX tags)
+- Content font size toggle (small / medium / large / extra large)
 - <img src="images/icons/width-expand.svg" width="16" height="16" alt="wide view"> Wide / <img src="images/icons/width-compress.svg" width="16" height="16" alt="narrow view"> narrow content width toggle
 - <img src="images/icons/raw.svg" width="16" height="16" alt="raw"> Raw markdown view
 - <img src="images/icons/copy.svg" width="16" height="16" alt="copy"> Copy content (Markdown / Text / HTML)

--- a/internal/frontend/src/App.test.tsx
+++ b/internal/frontend/src/App.test.tsx
@@ -1,5 +1,31 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { formatTitle, getInitialTocOpenMap, isTocOpenForFile, TOC_OPEN_STORAGE_KEY } from "./App";
+import {
+  FONT_SIZE_STORAGE_KEY,
+  formatTitle,
+  getInitialFontSize,
+  getInitialTocOpenMap,
+  isTocOpenForFile,
+  TOC_OPEN_STORAGE_KEY,
+} from "./App";
+
+describe("getInitialFontSize", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("returns medium when localStorage is empty", () => {
+    expect(getInitialFontSize()).toBe("medium");
+  });
+
+  it("returns stored size", () => {
+    localStorage.setItem(FONT_SIZE_STORAGE_KEY, "xlarge");
+    expect(getInitialFontSize()).toBe("xlarge");
+  });
+
+  it("returns medium for invalid value", () => {
+    localStorage.setItem(FONT_SIZE_STORAGE_KEY, "huge");
+    expect(getInitialFontSize()).toBe("medium");
+  });
+});
 
 describe("getInitialTocOpenMap", () => {
   beforeEach(() => localStorage.clear());

--- a/internal/frontend/src/App.tsx
+++ b/internal/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Sidebar } from "./components/Sidebar";
 import { MarkdownViewer } from "./components/MarkdownViewer";
 import { ThemeToggle } from "./components/ThemeToggle";
+import { FontSizeToggle, type FontSize } from "./components/FontSizeToggle";
 import { WidthToggle } from "./components/WidthToggle";
 import { GroupDropdown } from "./components/GroupDropdown";
 import { ViewModeToggle, type ViewMode } from "./components/ViewModeToggle";
@@ -25,7 +26,20 @@ import { isMarkdownFile } from "./utils/filetype";
 const VIEWMODE_STORAGE_KEY = "mo-sidebar-viewmode";
 const WIDTH_STORAGE_KEY = "mo-layout-width";
 const SHOW_TITLE_STORAGE_KEY = "mo-sidebar-show-title";
+export const FONT_SIZE_STORAGE_KEY = "mo-font-size";
 export const TOC_OPEN_STORAGE_KEY = "mo-toc-open";
+
+export function getInitialFontSize(): FontSize {
+  try {
+    const stored = localStorage.getItem(FONT_SIZE_STORAGE_KEY);
+    if (stored === "small" || stored === "medium" || stored === "large" || stored === "xlarge") {
+      return stored;
+    }
+  } catch {
+    /* ignore */
+  }
+  return "medium";
+}
 
 export function getInitialTocOpenMap(): Record<string, boolean> {
   try {
@@ -98,6 +112,7 @@ export function App() {
       return false;
     }
   });
+  const [fontSize, setFontSize] = useState<FontSize>(getInitialFontSize);
   const knownFileIds = useRef<Set<string>>(new Set());
   const [initialFileId, setInitialFileId] = useState<string | null>(() => {
     const fromUrl = parseFileIdFromSearch(window.location.search);
@@ -308,6 +323,14 @@ export function App() {
     }
   }, [isWide]);
 
+  useEffect(() => {
+    try {
+      localStorage.setItem(FONT_SIZE_STORAGE_KEY, fontSize);
+    } catch {
+      /* ignore */
+    }
+  }, [fontSize]);
+
   const handleViewModeToggle = useCallback(() => {
     setViewModes((prev) => {
       const current = prev[activeGroup] ?? "flat";
@@ -425,6 +448,7 @@ export function App() {
         <TitleToggle showTitle={currentShowTitle} onToggle={handleTitleToggle} />
         <SearchToggle isOpen={searchQuery != null} onToggle={handleSearchToggle} />
         <div className="ml-auto flex items-center gap-2">
+          <FontSizeToggle fontSize={fontSize} onChange={setFontSize} />
           <WidthToggle isWide={isWide} onToggle={() => setIsWide((v) => !v)} />
           <ThemeToggle />
         </div>
@@ -465,6 +489,7 @@ export function App() {
                 onRemoveFile={handleRemoveFile}
                 uploaded={activeFile?.uploaded}
                 isWide={isWide}
+                fontSize={fontSize}
                 onZoom={handleZoom}
                 scrollToHeading={pendingSearchHeading}
                 onScrolledToHeading={() => setPendingSearchHeading(null)}

--- a/internal/frontend/src/components/FontSizeToggle.test.tsx
+++ b/internal/frontend/src/components/FontSizeToggle.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FontSizeToggle } from "./FontSizeToggle";
+
+describe("FontSizeToggle", () => {
+  it("shows current size in title", () => {
+    render(<FontSizeToggle fontSize="medium" onChange={() => {}} />);
+    expect(screen.getByTitle("Text size: Medium text")).toBeInTheDocument();
+  });
+
+  it("cycles from small to medium", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<FontSizeToggle fontSize="small" onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Text size" }));
+    expect(onChange).toHaveBeenCalledWith("medium");
+  });
+
+  it("cycles from medium to large", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<FontSizeToggle fontSize="medium" onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Text size" }));
+    expect(onChange).toHaveBeenCalledWith("large");
+  });
+
+  it("cycles from large to xlarge", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<FontSizeToggle fontSize="large" onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Text size" }));
+    expect(onChange).toHaveBeenCalledWith("xlarge");
+  });
+
+  it("cycles from xlarge to small", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<FontSizeToggle fontSize="xlarge" onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Text size" }));
+    expect(onChange).toHaveBeenCalledWith("small");
+  });
+});

--- a/internal/frontend/src/components/FontSizeToggle.tsx
+++ b/internal/frontend/src/components/FontSizeToggle.tsx
@@ -1,0 +1,48 @@
+export type FontSize = "small" | "medium" | "large" | "xlarge";
+
+interface FontSizeToggleProps {
+  fontSize: FontSize;
+  onChange: (fontSize: FontSize) => void;
+}
+
+const LABELS: Record<FontSize, string> = {
+  small: "Small text",
+  medium: "Medium text",
+  large: "Large text",
+  xlarge: "Extra large text",
+};
+
+const NEXT_SIZE: Record<FontSize, FontSize> = {
+  small: "medium",
+  medium: "large",
+  large: "xlarge",
+  xlarge: "small",
+};
+
+export function FontSizeToggle({ fontSize, onChange }: FontSizeToggleProps) {
+  const nextSize = NEXT_SIZE[fontSize];
+
+  return (
+    <button
+      type="button"
+      className="flex min-w-10 items-center justify-center bg-transparent border border-gh-border rounded-md px-2 py-1.5 text-gh-header-text cursor-pointer transition-colors duration-150 hover:bg-gh-bg-hover"
+      onClick={() => onChange(nextSize)}
+      aria-label="Text size"
+      title={`Text size: ${LABELS[fontSize]}`}
+    >
+      <span
+        className={
+          fontSize === "small"
+            ? "text-sm"
+            : fontSize === "large"
+              ? "text-lg"
+              : fontSize === "xlarge"
+                ? "text-xl"
+                : ""
+        }
+      >
+        A
+      </span>
+    </button>
+  );
+}

--- a/internal/frontend/src/components/MarkdownViewer.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.tsx
@@ -24,6 +24,7 @@ import type { ZoomContent } from "./ZoomModal";
 import type { TocHeading } from "./TocPanel";
 import type { Components } from "react-markdown";
 import "github-markdown-css/github-markdown.css";
+import type { FontSize } from "./FontSizeToggle";
 
 // Strip the `user-content-` prefix that remark-gfm bakes into footnote IDs,
 // so rehype-sanitize can re-add it exactly once (avoiding double-prefixed IDs).
@@ -73,6 +74,7 @@ interface MarkdownViewerProps {
   onRemoveFile: () => void;
   uploaded?: boolean;
   isWide: boolean;
+  fontSize: FontSize;
   onZoom?: (content: ZoomContent) => void;
   scrollToHeading?: string | null;
   onScrolledToHeading?: () => void;
@@ -533,6 +535,7 @@ export function MarkdownViewer({
   onRemoveFile,
   uploaded,
   isWide,
+  fontSize,
   onZoom,
   scrollToHeading,
   onScrolledToHeading,
@@ -802,7 +805,7 @@ export function MarkdownViewer({
     <div className="flex items-start gap-2">
       <article
         ref={articleRef}
-        className={`markdown-body relative min-w-0 flex-1 overflow-visible${isWide ? " markdown-body--wide" : ""}`}
+        className={`markdown-body relative min-w-0 flex-1 overflow-visible${isWide ? " markdown-body--wide" : ""}${fontSize !== "medium" ? ` markdown-body--${fontSize}` : ""}`}
       >
         <div className="pointer-events-none absolute inset-0 z-10 overflow-visible">
           {searchHitMarkers.map((marker, index) => (

--- a/internal/frontend/src/styles/app.css
+++ b/internal/frontend/src/styles/app.css
@@ -37,8 +37,6 @@ body,
 .markdown-body {
   max-width: 980px;
   margin: 0 auto;
-  font-size: 16px;
-  line-height: 1.7;
 }
 
 .markdown-body.markdown-body--wide {
@@ -47,14 +45,17 @@ body,
 
 .markdown-body.markdown-body--small {
   font-size: 14px;
+  line-height: 1.7;
 }
 
 .markdown-body.markdown-body--large {
   font-size: 18px;
+  line-height: 1.6;
 }
 
 .markdown-body.markdown-body--xlarge {
   font-size: 20px;
+  line-height: 1.5;
 }
 
 /* Undo Tailwind preflight's display:block on img inside markdown

--- a/internal/frontend/src/styles/app.css
+++ b/internal/frontend/src/styles/app.css
@@ -37,10 +37,24 @@ body,
 .markdown-body {
   max-width: 980px;
   margin: 0 auto;
+  font-size: 16px;
+  line-height: 1.7;
 }
 
 .markdown-body.markdown-body--wide {
   max-width: none;
+}
+
+.markdown-body.markdown-body--small {
+  font-size: 14px;
+}
+
+.markdown-body.markdown-body--large {
+  font-size: 18px;
+}
+
+.markdown-body.markdown-body--xlarge {
+  font-size: 20px;
 }
 
 /* Undo Tailwind preflight's display:block on img inside markdown


### PR DESCRIPTION
## Summary

- add a content font size toggle to the Markdown viewer
- support four sizes: small, medium, large, and extra large
- persist the selected size in localStorage
- document the new toggle in README

## Why

People do not all find the same font size comfortable to read. Adding a font size toggle makes Markdown files easier to read for more people across different preferences, screen sizes, and display setups, especially for longer documents.

## User impact

Users can adjust the rendered Markdown content to a size that feels comfortable for them without changing browser zoom or page width. The preference is remembered between sessions.

## Validation

- `pnpm --dir internal/frontend run test`
- `make build`

## Screenshots

### Medium
<img width="2758" height="1178" alt="image" src="https://github.com/user-attachments/assets/c54fa524-8989-4c2b-bea4-67413ae14cf9" />


### Extra large
<img width="2766" height="1416" alt="image" src="https://github.com/user-attachments/assets/4134c067-a283-4a0c-abf8-bc4c74f1482c" />
