### PR TITLE
fix: decode percent-encoded non-ASCII paths in relative link handler

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1728,7 +1729,12 @@ func handleOpenFile(state *State) http.HandlerFunc {
 			return
 		}
 
-		absPath := filepath.Join(filepath.Dir(entry.Path), req.Path)
+		decodedPath, err := url.PathUnescape(req.Path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		absPath := filepath.Join(filepath.Dir(entry.Path), decodedPath)
 		absPath = filepath.Clean(absPath)
 
 		if _, err := os.Stat(absPath); err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1929,5 +1930,97 @@ func TestRemoveFileNotFound(t *testing.T) {
 	// Verify original file is still there
 	if len(s.groups[DefaultGroup].Files) != 1 {
 		t.Error("expected files to be unchanged")
+	}
+}
+
+func TestHandleOpenFile_PercentEncodedNonASCII(t *testing.T) {
+	// Create a temp directory with a non-ASCII markdown file
+	tmpDir := t.TempDir()
+	srcFile := filepath.Join(tmpDir, "index.md")
+	targetFile := filepath.Join(tmpDir, "日本語ファイル.md")
+
+	if err := os.WriteFile(srcFile, []byte("# Index"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetFile, []byte("# Japanese"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srcID := FileID(srcFile)
+	s := newTestState(t)
+	s.groups[DefaultGroup] = &Group{
+		Name: DefaultGroup,
+		Files: []*FileEntry{
+			{ID: srcID, Name: "index.md", Path: srcFile},
+		},
+	}
+
+	handler := NewHandler(s)
+
+	// Simulate browser behavior: percent-encode the non-ASCII filename
+	encodedPath := url.PathEscape("日本語ファイル.md")
+	body, err := json.Marshal(openFileRequest{FileID: srcID, Path: encodedPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/_/api/groups/%s/files/open", DefaultGroup), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var entry FileEntry
+	if err := json.NewDecoder(rec.Body).Decode(&entry); err != nil {
+		t.Fatal(err)
+	}
+	if entry.Path != targetFile {
+		t.Errorf("got path %q, want %q", entry.Path, targetFile)
+	}
+}
+
+func TestHandleFileRaw_PercentEncodedNonASCII(t *testing.T) {
+	// Create a temp directory with a non-ASCII asset file
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "index.md")
+	assetFile := filepath.Join(tmpDir, "画像.txt")
+
+	if err := os.WriteFile(mdFile, []byte("# Index"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(assetFile, []byte("asset content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mdID := FileID(mdFile)
+	s := newTestState(t)
+	s.groups[DefaultGroup] = &Group{
+		Name: DefaultGroup,
+		Files: []*FileEntry{
+			{ID: mdID, Name: "index.md", Path: mdFile},
+		},
+	}
+
+	handler := NewHandler(s)
+
+	// Percent-encode the non-ASCII filename in the URL path
+	encodedName := url.PathEscape("画像.txt")
+	reqURL := fmt.Sprintf("/_/api/groups/%s/files/%s/raw/%s", DefaultGroup, mdID, encodedName)
+	req := httptest.NewRequest("GET", reqURL, nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	got := rec.Body.String()
+	if !strings.Contains(got, "asset content") {
+		t.Errorf("expected body to contain %q, got %q", "asset content", got)
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1939,10 +1939,10 @@ func TestHandleOpenFile_PercentEncodedNonASCII(t *testing.T) {
 	srcFile := filepath.Join(tmpDir, "index.md")
 	targetFile := filepath.Join(tmpDir, "日本語ファイル.md")
 
-	if err := os.WriteFile(srcFile, []byte("# Index"), 0o644); err != nil {
+	if err := os.WriteFile(srcFile, []byte("# Index"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(targetFile, []byte("# Japanese"), 0o644); err != nil {
+	if err := os.WriteFile(targetFile, []byte("# Japanese"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1989,10 +1989,10 @@ func TestHandleFileRaw_PercentEncodedNonASCII(t *testing.T) {
 	mdFile := filepath.Join(tmpDir, "index.md")
 	assetFile := filepath.Join(tmpDir, "画像.txt")
 
-	if err := os.WriteFile(mdFile, []byte("# Index"), 0o644); err != nil {
+	if err := os.WriteFile(mdFile, []byte("# Index"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(assetFile, []byte("asset content"), 0o644); err != nil {
+	if err := os.WriteFile(assetFile, []byte("asset content"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary

- When a Markdown file contains a relative link to another `.md` file with non-ASCII characters (e.g. Japanese `日本語ファイル.md`), the browser percent-encodes the href in the click event
- `handleOpenFile` was passing the encoded path directly to `filepath.Join`, so `os.Stat` failed with "file not found"
- Added `url.PathUnescape()` to decode the path before constructing the absolute file path

Closes #172