### PR TITLE
feat: fix the position of file menu

### DIFF
--- a/internal/frontend/src/components/MarkdownViewer.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.tsx
@@ -822,7 +822,7 @@ export function MarkdownViewer({
         </div>
         {renderedContent}
       </article>
-      <div className="shrink-0 flex flex-col gap-2 -mr-4 -mt-4">
+      <div className="shrink-0 flex flex-col gap-2 -mr-4 -mt-4 sticky -top-4">
         {isMarkdown && <TocToggle isTocOpen={isTocOpen} onToggle={onTocToggle} />}
         {isMarkdown && <RawToggle isRaw={isRawView} onToggle={() => setIsRawView((v) => !v)} />}
         <CopyButton content={content} />


### PR DESCRIPTION
Thanks for the maintaining such a wonderful tool!
I'm using `mo` from inside neovim and this helps me a lot!

## WHAT
I fixed the position of file menu.
<img width="2002" height="1500" alt="CleanShot 2026-04-16 at 00 03 44@2x" src="https://github.com/user-attachments/assets/a9dfa9b2-aef7-4a8d-9882-344d369678fd" />

### AsIs
https://github.com/user-attachments/assets/8a70d985-e5c8-4ec7-8ac9-20db463298a6

### This PR
https://github.com/user-attachments/assets/fd67cd0e-ba14-4436-92e7-2b5f89d956fd

## WHY
Sometimes, I take a quick glance at ToC.

Currently, I should scroll to the top when I want to do it.

I believe this change improves UX in the above case.


## Test plan
I tested this change as following:

1. `make build ARG=README.md` (I don't know that `ARG` is needed.  🫥)
2. `./mo README.md`
3. Open `http://localhost:6275/` in my browser
