### PR TITLE
feat: make `<code>` element brighter in dark mode

### DIFF
--- a/internal/frontend/src/styles/app.css
+++ b/internal/frontend/src/styles/app.css
@@ -205,7 +205,7 @@ body,
   --fgColor-success: #3fb950;
   --bgColor-default: #0d1117;
   --bgColor-muted: #151b23;
-  --bgColor-neutral-muted: #656c7633;
+  --bgColor-neutral-muted: #3d444db3;
   --bgColor-attention-muted: #bb800926;
   --borderColor-default: #3d444d;
   --borderColor-muted: #3d444db3;


### PR DESCRIPTION
> [!NOTE]
> This PR is based on my personal preference.
>
> So, if you disagree with this PR, please feel free to close this PR.
>
> Still I can modify css using some chrome extension if this PR was closed. 👍

## WHAT
I made the color of `<code>` element brighter like below.

|before| <img width="2246" height="2152" alt="CleanShot 2026-04-18 at 00 13 50@2x" src="https://github.com/user-attachments/assets/cb7749c2-602d-46c0-a2a4-179a9e3d231f" />|
|---|---|
|after|<img width="2246" height="2152" alt="CleanShot 2026-04-18 at 00 14 43@2x" src="https://github.com/user-attachments/assets/1f7fab40-ec9b-4cea-8922-3b03560c2ade" />|

## WHY
It is a bit hard to find `<code>` element in dark mode for me.

But as I mentioned on the top of this PR, if you don't think so, please feel free to close.