### PR TITLE
fix: sort file lists in natural order (x/text/collate variant)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,8 @@ import (
 	"github.com/muesli/termenv"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
+	"golang.org/x/text/collate"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -612,7 +614,7 @@ func resolveArgs(args []string, withWatch bool) (files []string, dirPatterns []s
 				if len(fileMatches) == 0 {
 					return nil, nil, fmt.Errorf("no .md files in %s", absPath)
 				}
-				sort.Strings(fileMatches)
+				collate.New(language.Und, collate.Numeric).SortStrings(fileMatches)
 				files = append(files, fileMatches...)
 			}
 			continue

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -677,6 +677,33 @@ func TestResolveArgs_Directory(t *testing.T) {
 	}
 }
 
+func TestResolveArgs_DirectoryNaturalOrder(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"i1.md", "i2.md", "i10.md", "i11.md"} {
+		writeTestFile(t, filepath.Join(dir, name), []byte("# "+name))
+	}
+
+	files, _, err := resolveArgs([]string{dir}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(dir, "i1.md"),
+		filepath.Join(dir, "i2.md"),
+		filepath.Join(dir, "i10.md"),
+		filepath.Join(dir, "i11.md"),
+	}
+	if len(files) != len(want) {
+		t.Fatalf("got %d files, want %d: %v", len(files), len(want), files)
+	}
+	for i := range want {
+		if files[i] != want[i] {
+			t.Errorf("files[%d] = %q, want %q", i, files[i], want[i])
+		}
+	}
+}
+
 func TestResolveArgs_DirectoryWithWatch(t *testing.T) {
 	dir := t.TempDir()
 	writeTestFile(t, filepath.Join(dir, "a.md"), []byte("# A"))

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/text v0.36.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -31,4 +31,6 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
+golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/frontend/src/utils/buildTree.test.ts
+++ b/internal/frontend/src/utils/buildTree.test.ts
@@ -112,6 +112,27 @@ describe("buildTree", () => {
     expect(root.children[1].file?.id).toBe("1");
   });
 
+  it("sorts sibling files by natural order (i1, i2, ..., i10)", () => {
+    const files = [
+      makeFile("1", "/docs/i1.md"),
+      makeFile("2", "/docs/i10.md"),
+      makeFile("3", "/docs/i2.md"),
+      makeFile("4", "/docs/i11.md"),
+      makeFile("5", "/docs/i13.md"),
+      makeFile("6", "/docs/i3.md"),
+    ];
+    const root = buildTree(files);
+
+    expect(root.children.map((c) => c.name)).toEqual([
+      "i1.md",
+      "i2.md",
+      "i3.md",
+      "i10.md",
+      "i11.md",
+      "i13.md",
+    ]);
+  });
+
   it("mixes filesystem and uploaded files", () => {
     const files = [
       makeFile("1", "/docs/a.md"),

--- a/internal/frontend/src/utils/buildTree.ts
+++ b/internal/frontend/src/utils/buildTree.ts
@@ -123,12 +123,17 @@ function collapseSingleChild(node: TreeNode): void {
   }
 }
 
+const naturalCompare = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: "base",
+}).compare;
+
 function sortTree(node: TreeNode): void {
   node.children.sort((a, b) => {
     const aIsDir = a.file == null;
     const bIsDir = b.file == null;
     if (aIsDir !== bIsDir) return aIsDir ? -1 : 1;
-    return a.name.localeCompare(b.name);
+    return naturalCompare(a.name, b.name);
   });
   for (const child of node.children) {
     sortTree(child);

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,6 +25,8 @@ import (
 	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/mo/internal/static"
 	"github.com/k1LoW/mo/version"
+	"golang.org/x/text/collate"
+	"golang.org/x/text/language"
 )
 
 type FileEntry struct {
@@ -621,6 +623,7 @@ func (s *State) AddPattern(absPattern, groupName string) ([]*FileEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("glob expansion failed: %w", err)
 	}
+	collate.New(language.Und, collate.Numeric).SortStrings(matches)
 
 	var entries []*FileEntry
 	for _, m := range matches {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -500,6 +500,37 @@ func TestAddPattern_InitialExpansion(t *testing.T) {
 	}
 }
 
+func TestAddPattern_InitialExpansionNaturalOrder(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"i1.md", "i2.md", "i10.md", "i11.md"} {
+		os.WriteFile(filepath.Join(dir, name), []byte("# "+name), 0o600) //nolint:errcheck
+	}
+
+	s := newTestState(t)
+	pattern := filepath.Join(dir, "*.md")
+	entries, err := s.AddPattern(pattern, DefaultGroup)
+	if err != nil {
+		t.Fatalf("AddPattern returned error: %v", err)
+	}
+
+	want := []string{"i1.md", "i2.md", "i10.md", "i11.md"}
+	if len(entries) != len(want) {
+		t.Fatalf("got %d entries, want %d", len(entries), len(want))
+	}
+	for i, name := range want {
+		if entries[i].Name != name {
+			t.Errorf("entries[%d].Name = %q, want %q", i, entries[i].Name, name)
+		}
+	}
+
+	files := s.Groups()[0].Files
+	for i, name := range want {
+		if files[i].Name != name {
+			t.Errorf("group files[%d].Name = %q, want %q", i, files[i].Name, name)
+		}
+	}
+}
+
 func TestAddPattern_Duplicate(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "a.md"), []byte("# A"), 0o600) //nolint:errcheck


### PR DESCRIPTION
> [!NOTE]
> This is a personal preference rather than a must-have change. It is offered as a starting point for discussion — please feel free to close this PR without hesitation if it does not fit the direction you want for the project.

## Summary

When a directory contains files like `i1.md`, `i2.md`, …, `i10.md`, the sidebar currently shows them in lexicographic order (`i1`, `i10`, `i11`, …, `i2`). This change sorts such lists in natural order (digit runs compared as integers) so the reading order lines up with what most editors (VS Code, Finder, etc.) show.

Three places decide the initial order of files in the sidebar and were all lexicographic:

- `cmd/root.go` — directory argument expansion (`mo dir/`)
- `internal/server/server.go` — `--watch` glob initial expansion
- `internal/frontend/src/utils/buildTree.ts` — tree view sibling order

The Go sites now use `golang.org/x/text/collate` with the `Numeric` option; the frontend uses `Intl.Collator({ numeric: true, sensitivity: "base" })`. Both apply UCA-based collation so backend and browser stay consistent, including for non-ASCII filenames.

User drag-and-drop reorder is unaffected: the reordered state is persisted server-side and restored from backup, and that path takes precedence over the initial-sort sites touched here.



|before|after|
|---|---|
|<img width="234" height="512" alt="CleanShot 2026-04-18 at 23 32 12" src="https://github.com/user-attachments/assets/85d66a89-1884-4c9f-8c1b-f2ff9bbe9689" />|<img width="250" height="503" alt="CleanShot 2026-04-19 at 00 20 14" src="https://github.com/user-attachments/assets/ed26e2ad-a6c9-4804-a4e8-8c8365e579ad" />|

## Why `golang.org/x/text/collate`

`x/text` is already an indirect dependency; this PR promotes it to a direct one. Using the standard collation library avoids a hand-rolled comparator and keeps the sort semantics aligned with the browser's `Intl.Collator`.

The trade-off worth calling out: `x/text/collate` pulls in UCA/Unicode tables, so the final Go binary grows noticeably. Measured on `darwin/arm64` with the frontend assets held constant, the size goes from **25.28 MiB → 26.90 MiB (+1.62 MiB, roughly +6.4%)**. If this cost is undesirable, a lightweight alternative would be to implement natural comparison directly (e.g. chunking digit runs) in ~30 lines, at the expense of losing UCA-aware handling for non-ASCII names. I chose `collate` for semantic parity with the browser side, but I'm happy to switch approach if binary size is a higher priority.

## Test plan

- `go test ./...` (new tests cover both directory expansion and `--watch` glob initial order)
- `go vet ./...`
- Frontend `pnpm run test` (incl. a new `buildTree` natural-order case)
- Frontend `pnpm run lint` / `pnpm run fmt:check`
- Manual verification with a directory containing `i1.md..i13.md` (flat and tree view; `mo dir/`, `mo --watch 'dir/*.md'`, `mo dir/*.md`)
