### PR TITLE
feat: add --recursive (-R) flag and reshape --watch as a boolean toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,9 @@ cd internal/frontend && pnpm run dev
 - `--target` / `-t` — Tab group name (default: `"default"`)
 - `--open` — Always open browser
 - `--no-open` — Never open browser
-- `--watch` / `-w` — Glob pattern to watch for matching files (repeatable)
+- `--watch` / `-w` — Boolean flag that turns on watch mode; directory and glob positional arguments are registered as watch patterns
 - `--unwatch` — Remove a watched glob pattern (repeatable)
+- `--recursive` / `-R` — Recurse into subdirectories when a directory is given as an argument (expands `*.md` → `**/*.md`)
 - `--close` — Close files instead of opening them
 - `--clear` — Clear saved session for the specified port
 - `--status` — Show status of all running mo servers
@@ -107,9 +108,9 @@ cd internal/frontend && pnpm run dev
 - **Resizable panels**: Both `Sidebar.tsx` (left) and `TocPanel.tsx` (right) use the same drag-to-resize pattern with localStorage persistence. Left sidebar uses `e.clientX`, right panel uses `window.innerWidth - e.clientX`.
 - **Toolbar buttons in content area**: The toolbar column (ToC + Raw toggles) lives inside `MarkdownViewer.tsx`, positioned with `shrink-0 flex flex-col gap-2 -mr-4 -mt-4` to align with the header.
 - **State persistence**: Server state (files, groups, patterns) is backed up to `$XDG_STATE_HOME/mo/backup/mo-<port>.json` via `internal/backup`. On `--restart`, the server reloads this state to preserve the session. When starting a new server, backup is always restored and merged with CLI-specified files/patterns (restored entries first, CLI entries appended, duplicates skipped). The backup file is preserved across clean `--shutdown` and is only removed via the `--clear` path in the CLI.
-- **Directory arguments**: When a directory is passed as a CLI argument, `resolveArgs()` expands `dir/*.md` (non-watch mode) or converts to a `dir/*.md` watch pattern (with `--watch`). The `hasNonDirArgs()` helper ensures the `--watch` + file args mutual exclusion check only applies to actual file arguments, not directories.
+- **Positional arguments**: `resolveArgs(args, watchMode, recursive)` classifies each positional arg as a glob (via `hasGlobChars`), directory, or file. With `--watch`, globs and directories become watch patterns (`dir/*.md` or `dir/**/*.md` when `-R`). Without `--watch`, they are expanded once via `doublestar.Glob` / `filepath.Glob` and treated as files. Plain files are added directly. `--watch` alone without a glob/dir positional errors out (with a shell-expansion hint if only files were given).
 - **Stdin pipe**: When no file arguments are given and stdin is a pipe (not a terminal), content is read from stdin and treated as an uploaded file. Name is `stdin-<first 7 hex of SHA-256>.md` (deterministic, consistent with upload dedup). If a server is already running, content is POSTed to the upload API; otherwise it is passed as `UploadedFileData` to the new server. Combining stdin with file arguments or `--watch` returns an error. Max stdin size is 10MB (same as server upload limit).
-- **Glob pattern watching**: `--watch` registers glob patterns that are expanded to matching files and monitored for new files via fsnotify directory watches. Patterns are stored with reference-counted directory watches (`watchedDirs map[string]int`). `--unwatch` removes patterns and decrements watch ref counts. Groups persist as long as they have files or patterns.
+- **Glob pattern watching**: `--watch` turns on watch mode; directory and glob positional arguments are registered as patterns, then expanded to matching files and monitored for new files via fsnotify directory watches. Patterns are stored with reference-counted directory watches (`watchedDirs map[string]int`). `--unwatch` still takes a pattern value (repeatable) and removes patterns, decrementing watch ref counts. Groups persist as long as they have files or patterns.
 - **localStorage conventions**: All keys use `mo-` prefix (e.g., `mo-sidebar-width`, `mo-sidebar-viewmode`, `mo-sidebar-tree-collapsed`, `mo-theme`). Read patterns use `try/catch` around `JSON.parse` with fallback defaults.
 
 ## API Conventions

--- a/README.md
+++ b/README.md
@@ -101,23 +101,33 @@ $ mo notes.md --target notes      # Opens at http://localhost:6275/notes
 
 ![Group view](images/groups.png)
 
-### Glob pattern watching
+### Watch mode and glob patterns
 
-Use `--watch` (`-w`) to specify glob patterns. Matching files are opened automatically, and watched directories are monitored for new files.
-
-``` console
-$ mo --watch '**/*.md'                          # Watch and open all .md files recursively
-$ mo --watch 'docs/**/*.md' --target docs       # Watch docs/ tree in "docs" group
-$ mo --watch '*.md' --watch 'docs/**/*.md'      # Multiple patterns
-```
-
-When a directory is passed with `--watch`, it is automatically converted to a `dir/*.md` watch pattern:
+`--watch` (`-w`) turns on watch mode. Directory and glob positional arguments are registered as watch patterns, matching files are opened, and new matching files are picked up automatically.
 
 ``` console
-$ mo --watch docs/                             # Equivalent to mo --watch 'docs/*.md'
+$ mo -w '**/*.md'                              # Watch and open all .md files recursively
+$ mo -w 'docs/**/*.md' --target docs           # Watch docs/ tree in "docs" group
+$ mo -w '*.md' 'docs/**/*.md'                  # Multiple patterns (positional)
+$ mo -w docs/                                  # Watch docs/*.md
 ```
 
-`--watch` cannot be combined with file arguments. The `**` pattern matches directories recursively.
+Combine with `--recursive` (`-R`) to descend into subdirectories. Short flags can be combined:
+
+``` console
+$ mo -w -R docs/                               # Watch docs/**/*.md
+$ mo -wR docs/                                 # Same, short-combined
+```
+
+Without `--watch`, globs are expanded once and directory arguments open matching files without live-watching new additions:
+
+``` console
+$ mo docs/                                     # Open every .md directly in docs/
+$ mo -R docs/                                  # Open every .md under docs/ (recursive)
+$ mo 'docs/*.md'                               # Expand and open matching .md files
+```
+
+> **Note:** `--watch` is a boolean flag — it no longer takes a value. Pass patterns as positional arguments: `mo -w '**/*.md'` still works because the quoted glob lands in the positional list, but `mo --watch=PATTERN` is no longer accepted. Multiple patterns should be listed as separate positional arguments rather than repeating `-w`.
 
 #### Removing watch patterns
 
@@ -249,8 +259,9 @@ $ mo --status --json
 | `--open` | | | Always open browser |
 | `--no-open` | | | Never open browser |
 | `--status` | | | Show all running mo servers |
-| `--watch` | `-w` | | Glob pattern to watch for matching files (repeatable) |
+| `--watch` | `-w` | `false` | Treat directory and glob arguments as watch patterns |
 | `--unwatch` | | | Remove a watched glob pattern (repeatable) |
+| `--recursive` | `-R` | `false` | Recurse into subdirectories when a directory is given |
 | `--close` | | | Close files instead of opening them |
 | `--shutdown` | | | Shut down the running mo server |
 | `--restart` | | | Restart the running mo server |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/k1LoW/errors"
 
 	"github.com/k1LoW/donegroup"
@@ -39,6 +40,9 @@ const (
 	probeTimeoutFast = 500 * time.Millisecond
 	// probeTimeoutDefault is used when the server is expected to be running.
 	probeTimeoutDefault = 2 * time.Second
+
+	markdownGlob          = "*.md"
+	markdownGlobRecursive = "**/*.md"
 )
 
 var (
@@ -52,8 +56,9 @@ var (
 	restartServer                bool
 	foreground                   bool
 	statusServer                 bool
-	watchPatterns                []string
+	watchMode                    bool
 	unwatchPatterns              []string
+	recursive                    bool
 	closeFiles                   bool
 	clearBackup                  bool
 	jsonOutput                   bool
@@ -136,15 +141,24 @@ Supported Markdown Features:
   - MDX files (rendered as Markdown with import/export stripped and JSX tags escaped)
   - Raw HTML
 
-Glob Patterns:
-  Use --watch (-w) to specify glob patterns. Matching directories are
-  watched and new files are automatically added.
-  Cannot be combined with file arguments.
+Watch mode and glob patterns:
+  --watch (-w) turns on watch mode. Directory and glob positional
+  arguments are then registered as watch patterns; matching files are
+  opened and new files are picked up automatically. Combine with
+  --recursive (-R) to descend into subdirectories.
 
   $ mo -w '**/*.md'                   Watch all .md files recursively
   $ mo -w 'docs/**/*.md' -t docs      Watch docs/ tree in "docs" group
-  $ mo -w '*.md' -w 'docs/**/*.md'    Watch multiple patterns
+  $ mo -w '*.md' 'docs/**/*.md'       Multiple patterns (positional)
+  $ mo -w docs/                       Watch docs/*.md
+  $ mo -w -R docs/                    Watch docs/**/*.md
+  $ mo -wR docs/                      Same (short-combined form)
   $ mo --unwatch '**/*.md'            Stop watching a pattern
+
+  Without --watch, globs are expanded once and a directory argument
+  opens the matching files without live-watching new additions.
+
+  $ mo -R docs/                       Open every .md under docs/ once
 
 WARNING: --bind with a non-loopback address:
   Binding to a non-localhost address (e.g. 0.0.0.0) exposes mo to the
@@ -176,8 +190,9 @@ func init() {
 	rootCmd.Flags().MarkHidden("restore") //nolint:errcheck
 	rootCmd.Flags().BoolVar(&foreground, "foreground", false, "Run mo server in foreground (do not background)")
 	rootCmd.Flags().BoolVar(&statusServer, "status", false, "Show status of all running mo servers")
-	rootCmd.Flags().StringArrayVarP(&watchPatterns, "watch", "w", nil, "Glob pattern to watch for matching files (repeatable)")
+	rootCmd.Flags().BoolVarP(&watchMode, "watch", "w", false, "Treat directory and glob arguments as watch patterns")
 	rootCmd.Flags().StringArrayVar(&unwatchPatterns, "unwatch", nil, "Remove a watched glob pattern (repeatable)")
+	rootCmd.Flags().BoolVarP(&recursive, "recursive", "R", false, "Recurse into subdirectories when a directory is given")
 	rootCmd.Flags().BoolVar(&closeFiles, "close", false, "Close files instead of opening them")
 	rootCmd.Flags().BoolVar(&clearBackup, "clear", false, "Clear saved session for the specified port")
 	rootCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output structured data as JSON to stdout")
@@ -262,7 +277,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(unwatchPatterns) > 0 {
-		if len(watchPatterns) > 0 {
+		if watchMode {
 			return fmt.Errorf("cannot use --unwatch with --watch")
 		}
 		if len(args) > 0 {
@@ -283,7 +298,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	if closeFiles {
-		if len(watchPatterns) > 0 {
+		if watchMode {
 			return fmt.Errorf("cannot use --close with --watch")
 		}
 		if len(args) == 0 {
@@ -320,28 +335,20 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	target = resolved
 
-	// Check --watch + file args mutual exclusion before resolving args.
-	// Directory args are allowed with --watch (they become patterns).
-	if len(watchPatterns) > 0 && len(args) > 0 {
-		if hasNonDirArgs(args) {
-			hasGlob := slices.ContainsFunc(watchPatterns, func(p string) bool {
-				return hasGlobChars(p)
-			})
-			if !hasGlob {
-				return fmt.Errorf("cannot use --watch (-w) with file arguments\n(hint: the shell may have expanded the glob pattern; quote it to prevent expansion, e.g. -w '**/*.md')")
-			}
-			return fmt.Errorf("cannot use --watch (-w) with file arguments")
+	if recursive && len(args) == 0 {
+		return fmt.Errorf("--recursive (-R) requires a directory argument")
+	}
+
+	files, patterns, err := resolveArgs(args, watchMode, recursive)
+	if err != nil {
+		return err
+	}
+
+	if watchMode && len(patterns) == 0 {
+		if len(files) > 0 {
+			return fmt.Errorf("--watch (-w) requires a glob pattern or directory argument\n(hint: the shell may have expanded the glob pattern; quote it, e.g. -w '**/*.md')")
 		}
-	}
-
-	files, dirPatterns, err := resolveArgs(args, len(watchPatterns) > 0)
-	if err != nil {
-		return err
-	}
-
-	patterns, err := resolvePatterns(slices.Concat(watchPatterns, dirPatterns))
-	if err != nil {
-		return err
+		return fmt.Errorf("--watch (-w) requires a glob pattern or directory argument")
 	}
 
 	// Detect redirected stdin when no positional arguments are given.
@@ -350,7 +357,7 @@ func run(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
 			return fmt.Errorf("cannot use redirected stdin with positional arguments")
 		}
-		if len(watchPatterns) > 0 {
+		if watchMode {
 			return fmt.Errorf("cannot use --watch (-w) with redirected stdin")
 		}
 		name, content, err := readStdin(os.Stdin)
@@ -546,25 +553,6 @@ func hasGlobChars(s string) bool {
 	return strings.ContainsAny(s, "*?[")
 }
 
-func hasNonDirArgs(args []string) bool {
-	for _, arg := range args {
-		absPath, err := filepath.Abs(arg)
-		if err != nil {
-			// Let resolveArgs surface the underlying error.
-			continue
-		}
-		info, err := os.Stat(absPath)
-		if err != nil {
-			// Path doesn't exist or can't be stat'd; let resolveArgs report it.
-			continue
-		}
-		if !info.IsDir() {
-			return true
-		}
-	}
-	return false
-}
-
 func resolvePatterns(patterns []string) ([]string, error) {
 	var resolved []string
 	for _, pat := range patterns {
@@ -580,46 +568,76 @@ func resolvePatterns(patterns []string) ([]string, error) {
 	return resolved, nil
 }
 
-func resolveArgs(args []string, withWatch bool) (files []string, dirPatterns []string, err error) {
+func resolveArgs(args []string, watchMode, recursive bool) (files, patterns []string, err error) {
 	for _, arg := range args {
-		absPath, err := filepath.Abs(arg)
+		abs, err := filepath.Abs(arg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot resolve path %s: %w", arg, err)
 		}
-		stat, err := os.Stat(absPath)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return nil, nil, fmt.Errorf("file not found: %s", absPath)
+
+		if hasGlobChars(arg) {
+			if watchMode {
+				patterns = append(patterns, abs)
+				continue
 			}
-			return nil, nil, fmt.Errorf("cannot stat path %s: %w", absPath, err)
-		}
-		if stat.IsDir() {
-			if withWatch {
-				dirPatterns = append(dirPatterns, filepath.Join(absPath, "*.md"))
-			} else {
-				matches, err := filepath.Glob(filepath.Join(absPath, "*.md"))
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to glob directory %s: %w", absPath, err)
-				}
-				var fileMatches []string
-				for _, m := range matches {
-					info, err := os.Stat(m)
-					if err != nil || info.IsDir() {
-						continue
-					}
-					fileMatches = append(fileMatches, m)
-				}
-				if len(fileMatches) == 0 {
-					return nil, nil, fmt.Errorf("no .md files in %s", absPath)
-				}
-				sort.Strings(fileMatches)
-				files = append(files, fileMatches...)
+			matches, err := expandGlobPattern(abs)
+			if err != nil {
+				return nil, nil, err
 			}
+			if len(matches) == 0 {
+				return nil, nil, fmt.Errorf("no files matched %s", arg)
+			}
+			files = append(files, matches...)
 			continue
 		}
-		files = append(files, absPath)
+
+		stat, err := os.Stat(abs)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, nil, fmt.Errorf("file not found: %s", abs)
+			}
+			return nil, nil, fmt.Errorf("cannot stat path %s: %w", abs, err)
+		}
+		if stat.IsDir() {
+			pat := filepath.Join(abs, markdownGlobFor(recursive))
+			if watchMode {
+				patterns = append(patterns, pat)
+				continue
+			}
+			matches, err := expandGlobPattern(pat)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(matches) == 0 {
+				return nil, nil, fmt.Errorf("no .md files in %s", abs)
+			}
+			files = append(files, matches...)
+			continue
+		}
+		files = append(files, abs)
 	}
-	return files, dirPatterns, nil
+	return files, patterns, nil
+}
+
+func markdownGlobFor(recursive bool) string {
+	if recursive {
+		return markdownGlobRecursive
+	}
+	return markdownGlob
+}
+
+func expandGlobPattern(absPattern string) ([]string, error) {
+	base, rel := doublestar.SplitPattern(filepath.ToSlash(absPattern))
+	rels, err := doublestar.Glob(os.DirFS(base), rel, doublestar.WithFilesOnly())
+	if err != nil {
+		return nil, fmt.Errorf("failed to expand glob %s: %w", absPattern, err)
+	}
+	matches := make([]string, len(rels))
+	for i, r := range rels {
+		matches[i] = filepath.Join(base, r)
+	}
+	sort.Strings(matches)
+	return matches, nil
 }
 
 func postFiles(client *http.Client, addr, group string, files []string) []deeplinkEntry {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -38,10 +38,10 @@ func TestResolvePatterns_Valid(t *testing.T) {
 
 func TestRun_UnwatchWithWatch(t *testing.T) {
 	unwatchPatterns = []string{"**/*.md"}
-	watchPatterns = []string{"**/*.md"}
+	watchMode = true
 	defer func() {
 		unwatchPatterns = nil
-		watchPatterns = nil
+		watchMode = false
 	}()
 
 	err := run(rootCmd, nil)
@@ -85,10 +85,10 @@ func TestRun_Close(t *testing.T) {
 
 	t.Run("with watch returns error", func(t *testing.T) {
 		closeFiles = true
-		watchPatterns = []string{"**/*.md"}
+		watchMode = true
 		defer func() {
 			closeFiles = false
-			watchPatterns = nil
+			watchMode = false
 		}()
 
 		err := run(rootCmd, []string{"README.md"})
@@ -102,45 +102,41 @@ func TestRun_Close(t *testing.T) {
 	})
 }
 
-func TestRun_WatchWithArgs(t *testing.T) {
-	t.Run("with glob pattern", func(t *testing.T) {
-		f := filepath.Join(t.TempDir(), "test.md")
-		writeTestFile(t, f, []byte("# Test"))
+func TestRun_Watch(t *testing.T) {
+	t.Run("no args errors", func(t *testing.T) {
+		watchMode = true
+		defer func() { watchMode = false }()
 
-		watchPatterns = []string{"**/*.md"}
-		defer func() { watchPatterns = nil }()
-
-		err := run(rootCmd, []string{f})
+		err := run(rootCmd, nil)
 		if err == nil {
-			t.Fatal("run should return error when --watch and args are both specified")
+			t.Fatal("run should return error when --watch has no pattern or directory argument")
 		}
-		want := "cannot use --watch (-w) with file arguments"
-		if err.Error() != want {
-			t.Fatalf("got error %q, want %q", err.Error(), want)
+		if !strings.Contains(err.Error(), "requires a glob pattern or directory argument") {
+			t.Fatalf("got error %q, want 'requires a glob pattern or directory argument'", err.Error())
 		}
 	})
 
-	t.Run("without glob chars hints shell expansion", func(t *testing.T) {
+	t.Run("only file args hints shell expansion", func(t *testing.T) {
 		f1 := filepath.Join(t.TempDir(), "a.md")
 		writeTestFile(t, f1, []byte("# A"))
 		f2 := filepath.Join(t.TempDir(), "b.md")
 		writeTestFile(t, f2, []byte("# B"))
 
-		watchPatterns = []string{f1}
-		defer func() { watchPatterns = nil }()
+		watchMode = true
+		defer func() { watchMode = false }()
 
-		err := run(rootCmd, []string{f2})
+		err := run(rootCmd, []string{f1, f2})
 		if err == nil {
-			t.Fatal("run should return error when --watch and args are both specified")
+			t.Fatal("run should return error when --watch is given only regular file arguments")
 		}
 		if !strings.Contains(err.Error(), "shell may have expanded") {
 			t.Fatalf("error should hint shell expansion, got %q", err.Error())
 		}
 	})
 
-	t.Run("non-existent file with watch returns file not found", func(t *testing.T) {
-		watchPatterns = []string{"**/*.md"}
-		defer func() { watchPatterns = nil }()
+	t.Run("non-existent arg returns file not found", func(t *testing.T) {
+		watchMode = true
+		defer func() { watchMode = false }()
 
 		err := run(rootCmd, []string{"nonexistent.md"})
 		if err == nil {
@@ -150,6 +146,20 @@ func TestRun_WatchWithArgs(t *testing.T) {
 			t.Fatalf("got error %q, want file not found error", err.Error())
 		}
 	})
+}
+
+func TestRun_RecursiveRequiresArgs(t *testing.T) {
+	recursive = true
+	defer func() { recursive = false }()
+
+	err := run(rootCmd, nil)
+	if err == nil {
+		t.Fatal("run should return error when --recursive is used without any argument")
+	}
+	want := "--recursive (-R) requires a directory argument"
+	if err.Error() != want {
+		t.Fatalf("got error %q, want %q", err.Error(), want)
+	}
 }
 
 func TestMergeGroups(t *testing.T) {
@@ -660,12 +670,12 @@ func TestResolveArgs_Directory(t *testing.T) {
 	writeTestFile(t, filepath.Join(dir, "b.md"), []byte("# B"))
 	writeTestFile(t, filepath.Join(dir, "c.txt"), []byte("text"))
 
-	files, dirPatterns, err := resolveArgs([]string{dir}, false)
+	files, patterns, err := resolveArgs([]string{dir}, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(dirPatterns) != 0 {
-		t.Fatalf("got %d dirPatterns, want 0", len(dirPatterns))
+	if len(patterns) != 0 {
+		t.Fatalf("got %d patterns, want 0", len(patterns))
 	}
 	if len(files) != 2 {
 		t.Fatalf("got %d files, want 2: %v", len(files), files)
@@ -681,26 +691,117 @@ func TestResolveArgs_DirectoryWithWatch(t *testing.T) {
 	dir := t.TempDir()
 	writeTestFile(t, filepath.Join(dir, "a.md"), []byte("# A"))
 
-	files, dirPatterns, err := resolveArgs([]string{dir}, true)
+	files, patterns, err := resolveArgs([]string{dir}, true, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(files) != 0 {
 		t.Fatalf("got %d files, want 0", len(files))
 	}
-	if len(dirPatterns) != 1 {
-		t.Fatalf("got %d dirPatterns, want 1", len(dirPatterns))
+	if len(patterns) != 1 {
+		t.Fatalf("got %d patterns, want 1", len(patterns))
 	}
 	want := filepath.Join(dir, "*.md")
-	if dirPatterns[0] != want {
-		t.Errorf("got pattern %q, want %q", dirPatterns[0], want)
+	if patterns[0] != want {
+		t.Errorf("got pattern %q, want %q", patterns[0], want)
+	}
+}
+
+func TestResolveArgs_DirectoryWithWatchRecursive(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "a.md"), []byte("# A"))
+
+	files, patterns, err := resolveArgs([]string{dir}, true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("got %d files, want 0", len(files))
+	}
+	if len(patterns) != 1 {
+		t.Fatalf("got %d patterns, want 1", len(patterns))
+	}
+	want := filepath.Join(dir, "**/*.md")
+	if patterns[0] != want {
+		t.Errorf("got pattern %q, want %q", patterns[0], want)
+	}
+}
+
+func TestResolveArgs_DirectoryRecursive(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "a.md"), []byte("# A"))
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(sub, "b.md"), []byte("# B"))
+	writeTestFile(t, filepath.Join(sub, "c.txt"), []byte("text"))
+
+	files, patterns, err := resolveArgs([]string{dir}, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(patterns) != 0 {
+		t.Fatalf("got %d patterns, want 0", len(patterns))
+	}
+	if len(files) != 2 {
+		t.Fatalf("got %d files, want 2: %v", len(files), files)
+	}
+	wantNested := filepath.Join(sub, "b.md")
+	foundNested := false
+	for _, f := range files {
+		if f == wantNested {
+			foundNested = true
+			break
+		}
+	}
+	if !foundNested {
+		t.Errorf("recursive expansion missed nested file %q in %v", wantNested, files)
+	}
+}
+
+func TestResolveArgs_GlobPositional_WatchMode(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "a.md"), []byte("# A"))
+	pattern := filepath.Join(dir, "*.md")
+
+	files, patterns, err := resolveArgs([]string{pattern}, true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("got %d files, want 0", len(files))
+	}
+	if len(patterns) != 1 {
+		t.Fatalf("got %d patterns, want 1: %v", len(patterns), patterns)
+	}
+	if !filepath.IsAbs(patterns[0]) {
+		t.Errorf("pattern %q is not absolute", patterns[0])
+	}
+}
+
+func TestResolveArgs_GlobPositional_NonWatch(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "a.md"), []byte("# A"))
+	writeTestFile(t, filepath.Join(dir, "b.md"), []byte("# B"))
+	pattern := filepath.Join(dir, "*.md")
+
+	files, patterns, err := resolveArgs([]string{pattern}, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(patterns) != 0 {
+		t.Fatalf("got %d patterns, want 0", len(patterns))
+	}
+	if len(files) != 2 {
+		t.Fatalf("got %d files, want 2: %v", len(files), files)
 	}
 }
 
 func TestResolveArgs_EmptyDirectory(t *testing.T) {
 	dir := t.TempDir()
 
-	_, _, err := resolveArgs([]string{dir}, false)
+	_, _, err := resolveArgs([]string{dir}, false, false)
 	if err == nil {
 		t.Fatal("expected error for empty directory")
 	}
@@ -826,15 +927,15 @@ func TestReadStdin(t *testing.T) {
 func TestResolveArgs_EmptyDirectoryWithWatch(t *testing.T) {
 	dir := t.TempDir()
 
-	files, dirPatterns, err := resolveArgs([]string{dir}, true)
+	files, patterns, err := resolveArgs([]string{dir}, true, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(files) != 0 {
 		t.Fatalf("got %d files, want 0", len(files))
 	}
-	if len(dirPatterns) != 1 {
-		t.Fatalf("got %d dirPatterns, want 1", len(dirPatterns))
+	if len(patterns) != 1 {
+		t.Fatalf("got %d patterns, want 1", len(patterns))
 	}
 }
 
@@ -845,12 +946,12 @@ func TestResolveArgs_MixedFilesAndDirs(t *testing.T) {
 	singleFile := filepath.Join(t.TempDir(), "standalone.md")
 	writeTestFile(t, singleFile, []byte("# Standalone"))
 
-	files, dirPatterns, err := resolveArgs([]string{dir, singleFile}, false)
+	files, patterns, err := resolveArgs([]string{dir, singleFile}, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(dirPatterns) != 0 {
-		t.Fatalf("got %d dirPatterns, want 0", len(dirPatterns))
+	if len(patterns) != 0 {
+		t.Fatalf("got %d patterns, want 0", len(patterns))
 	}
 	if len(files) != 2 {
 		t.Fatalf("got %d files, want 2: %v", len(files), files)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -775,14 +776,7 @@ func TestResolveArgs_DirectoryRecursive(t *testing.T) {
 		t.Fatalf("got %d files, want 2: %v", len(files), files)
 	}
 	wantNested := filepath.Join(sub, "b.md")
-	foundNested := false
-	for _, f := range files {
-		if f == wantNested {
-			foundNested = true
-			break
-		}
-	}
-	if !foundNested {
+	if !slices.Contains(files, wantNested) {
 		t.Errorf("recursive expansion missed nested file %q in %v", wantNested, files)
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> This is a personal preference rather than a must-have change. Because it involves a breaking change in flag semantics, it is offered strictly as a proposal for discussion — please feel free to close this PR without hesitation if the direction does not fit the project.

## Motivation

Watching a directory tree today requires typing the glob by hand:

```console
$ mo --watch 'docs/**/*.md'
```

It would be convenient to express the same intent with a directory argument plus a short flag, the way tools such as `ls -R` or `grep -R` do:

```console
$ mo -wR docs/
```

Reaching that ergonomy with the current flag shape is not possible: `--watch` takes a value, so `-w -R docs/` is parsed as `-w` consuming `-R` as its value. This PR introduces `--recursive` (`-R`) and, to make the short-combined form work, turns `--watch` into a boolean toggle with glob patterns read from positional arguments.

### Why reshaping `--watch` is necessary

The first, non-breaking approach would be to add `--recursive` / `-R` while leaving `--watch` as it is today. Under that shape, `mo -w -R docs/` does **not** parse as intended: because the current `--watch` takes a string value, `pflag` consumes `-R` as that value.

In other words, under a non-breaking approach `mo -w -R docs/` (and the short-combined `mo -wR docs/`) cannot be supported — `-w` consumes the next token as its value, so the short-combined form cannot coexist with a value-taking `--watch`. The only way to express a recursive watch would stay `mo -w 'docs/**/*.md'`.

Turning `--watch` into a boolean toggle is what removes that constraint. That is the breaking part of this proposal: it is offered as the minimal change required to make `-wR docs/` parse naturally, and glob patterns move to positional arguments as a consequence.

## Behaviour

- `--watch` / `-w` is a **boolean**: it turns on watch mode.
- `--recursive` / `-R` is a **boolean**: when a directory is passed as a positional argument, it expands `*.md` → `**/*.md`. It has no effect on file or glob arguments.
- Positional arguments are classified as glob patterns (via `hasGlobChars`), directories, or plain files. Under watch mode, globs and directories become watch patterns; otherwise they are expanded once and opened.

### Examples

```console
$ mo -w -R docs/          # Watch docs/**/*.md
$ mo -wR docs/            # Same (short-combined)
$ mo -w 'docs/**/*.md'    # Same (glob passed positionally — unchanged)
$ mo -R docs/             # Open every .md under docs/ once, without watching
$ mo docs/                # Existing behaviour: open docs/*.md
```

### Error paths

- `--watch` with no glob or directory argument → error. If only regular files were given, the error includes a hint that the shell may have expanded the glob.
- `--recursive` without any argument → error.

## Breaking changes

Because `--watch` becomes a boolean, these forms stop parsing and would need rewriting:

- `--watch=VALUE` / `-w=VALUE` (equal-sign form) — `pflag` rejects non-bool values for boolean flags.
- Multiple `-w PAT1 -w PAT2` invocations — patterns need to be consolidated as positional arguments: `mo -w 'PAT1' 'PAT2'`.

Space-separated single-pattern forms such as `mo -w PATTERN` continue to work as-is because the quoted glob falls through to the positional list.

The backup file format (`internal/backup`) and the `POST /_/api/patterns` server API are unchanged, so session restore and external API clients are not affected.

## Design notes

- `resolveArgs(args, watchMode, recursive)` classifies each positional arg via `hasGlobChars` → glob pattern, `os.Stat` → directory, else plain file. Globs and directories build an absolute pattern (`dir/*.md` or `dir/**/*.md` when recursive). Non-watch expansion uses `doublestar.Glob(os.DirFS(base), rel, WithFilesOnly())`, so expansion semantics stay aligned with the existing pattern walker in `internal/server/server.go`.
- The `hasNonDirArgs` helper became unused after the refactor and was removed.

## Test plan

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- Manual smoke: `mo -wR <dir>` picks up nested `.md` files; `mo -w` (no args) and `mo -w <file.md>` error with the shell-expansion hint; `mo -R` (no args) errors.
