### PR TITLE
feat: add @media print styles for better print preview

### DIFF
--- a/internal/frontend/src/styles/app.css
+++ b/internal/frontend/src/styles/app.css
@@ -247,3 +247,24 @@ body,
   --color-prettylights-syntax-invalid-illegal-bg: var(--bgColor-danger-muted);
   --color-prettylights-syntax-invalid-illegal-text: var(--fgColor-danger);
 }
+
+@media print {
+  * {
+    overflow: visible !important;
+    scrollbar-width: none !important;
+  }
+
+  *::-webkit-scrollbar {
+    display: none !important;
+  }
+
+  aside,
+  button,
+  header {
+    display: none !important;
+  }
+
+  .markdown-body {
+    max-width: 980px !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `@media print` CSS rules to improve print preview (#191)
- Hide sidebar, buttons, and header in print view
- Force all elements to `overflow: visible` so full content is printed
- Cap `.markdown-body` at 980px to prevent Wide view from overflowing horizontally

Closes #191