### PR TITLE
fix(frontend): sync URL with active file across all selection paths

### DIFF
--- a/internal/frontend/src/App.test.tsx
+++ b/internal/frontend/src/App.test.tsx
@@ -1,5 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
+  App,
   FONT_SIZE_STORAGE_KEY,
   formatTitle,
   getInitialFontSize,
@@ -7,6 +10,20 @@ import {
   isTocOpenForFile,
   TOC_OPEN_STORAGE_KEY,
 } from "./App";
+
+// Mocks are hoisted by vi.mock so heavy render dependencies never load in jsdom.
+vi.mock("./components/MarkdownViewer", () => ({
+  MarkdownViewer: ({ fileId }: { fileId: string }) => <div data-testid="viewer">{fileId}</div>,
+}));
+
+vi.mock("./hooks/useSSE", () => ({ useSSE: () => {} }));
+
+vi.mock("./hooks/useFileDrop", () => ({ useFileDrop: () => ({ isDragging: false }) }));
+
+vi.mock("./hooks/useScrollRestoration", () => ({
+  SCROLL_SESSION_KEY: "mo-scroll-context",
+  useScrollRestoration: () => ({ captureScrollPosition: () => {}, onContentRendered: () => {} }),
+}));
 
 describe("getInitialFontSize", () => {
   beforeEach(() => localStorage.clear());
@@ -89,5 +106,132 @@ describe("formatTitle", () => {
 
   it("returns `title - file name` when title is defined", () => {
     expect(formatTitle({ name: "file.md", title: "File Title" })).toBe("File Title - file.md | mo");
+  });
+});
+
+describe("App URL sync", () => {
+  const groupsPayload = [
+    {
+      name: "default",
+      files: [
+        { id: "aaa11111", name: "README.md", path: "/README.md" },
+        { id: "bbb22222", name: "GUIDE.md", path: "/GUIDE.md" },
+      ],
+    },
+    {
+      name: "design",
+      files: [{ id: "ccc33333", name: "spec.md", path: "/design/spec.md" }],
+    },
+  ];
+
+  function mockFetch() {
+    return vi.fn().mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/_/api/groups") {
+        return Promise.resolve({ ok: true, json: async () => groupsPayload });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+  }
+
+  function setUrl(url: string) {
+    window.history.replaceState(null, "", url);
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    setUrl("/");
+    vi.stubGlobal("fetch", mockFetch());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    setUrl("/");
+  });
+
+  it("updates URL with ?file= when a file is clicked in the sidebar", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Wait for groups to load and the auto-selected first file to render.
+    await screen.findByText("GUIDE.md");
+
+    await user.click(screen.getByText("GUIDE.md"));
+
+    await waitFor(() => {
+      expect(window.location.pathname + window.location.search).toBe("/?file=bbb22222");
+    });
+  });
+
+  it("pushes a new history entry on file selection (back returns to the previous file)", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("README.md");
+    // The first file is auto-selected; URL is replaced (not pushed).
+    await waitFor(() => {
+      expect(window.location.search).toBe("?file=aaa11111");
+    });
+
+    const startLength = window.history.length;
+    await user.click(screen.getByText("GUIDE.md"));
+
+    await waitFor(() => {
+      expect(window.location.search).toBe("?file=bbb22222");
+    });
+    expect(window.history.length).toBe(startLength + 1);
+  });
+
+  it("hydrates the active file from ?file= on initial load", async () => {
+    setUrl("/?file=bbb22222");
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("viewer")).toHaveTextContent("bbb22222");
+    });
+    // URL is preserved (no push, no clear).
+    expect(window.location.search).toBe("?file=bbb22222");
+  });
+
+  it("falls back to the first file when ?file= references an unknown id", async () => {
+    setUrl("/?file=zzz99999");
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("viewer")).toHaveTextContent("aaa11111");
+    });
+    // URL is rewritten via replaceState to match the actual selected file.
+    await waitFor(() => {
+      expect(window.location.search).toBe("?file=aaa11111");
+    });
+  });
+
+  it("follows back/forward navigation via popstate", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("README.md");
+    await waitFor(() => {
+      expect(window.location.search).toBe("?file=aaa11111");
+    });
+
+    await user.click(screen.getByText("GUIDE.md"));
+    await waitFor(() => {
+      expect(window.location.search).toBe("?file=bbb22222");
+    });
+
+    // Simulate browser Back: rewind URL, then dispatch popstate as the browser would.
+    act(() => {
+      window.history.replaceState(null, "", "/?file=aaa11111");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("viewer")).toHaveTextContent("aaa11111");
+    });
+    // URL is not re-pushed by the popstate-driven state change.
+    expect(window.location.search).toBe("?file=aaa11111");
   });
 });

--- a/internal/frontend/src/App.tsx
+++ b/internal/frontend/src/App.tsx
@@ -20,7 +20,13 @@ import { useActiveHeading } from "./hooks/useActiveHeading";
 import { useScrollRestoration, SCROLL_SESSION_KEY } from "./hooks/useScrollRestoration";
 import type { FileEntry, Group, SearchResult } from "./hooks/useApi";
 import { fetchGroups, fetchSearchResults, removeFile, reorderFiles } from "./hooks/useApi";
-import { allFileIds, parseGroupFromPath, parseFileIdFromSearch, groupToPath } from "./utils/groups";
+import {
+  allFileIds,
+  parseGroupFromPath,
+  parseFileIdFromSearch,
+  groupToPath,
+  buildFileUrl,
+} from "./utils/groups";
 import { isMarkdownFile } from "./utils/filetype";
 
 const VIEWMODE_STORAGE_KEY = "mo-sidebar-viewmode";
@@ -213,20 +219,27 @@ export function App() {
       .catch(() => {});
   }, []);
 
-  // Sync URL path with active group
+  // User-initiated navigation (file/group selection) calls pushState directly at
+  // the call site. This effect only reconciles the URL with state for automatic
+  // changes (initial mount, SSE updates, render-time fallbacks) via replaceState.
   useEffect(() => {
-    const expectedPath = groupToPath(activeGroup);
-    if (window.location.pathname !== expectedPath) {
-      window.history.replaceState(null, "", expectedPath);
-    }
-  }, [activeGroup]);
+    // initialFileId hasn't been consumed yet — keep the URL as the user landed.
+    if (initialFileId != null) return;
+    const expectedUrl = activeFileId
+      ? buildFileUrl(activeGroup, activeFileId)
+      : groupToPath(activeGroup);
+    if (window.location.pathname + window.location.search === expectedUrl) return;
+    window.history.replaceState(null, "", expectedUrl);
+  }, [activeGroup, activeFileId, initialFileId]);
 
-  // Clear search params after consuming initial file ID
   useEffect(() => {
-    if (initialFileId === null && window.location.search) {
-      window.history.replaceState(null, "", window.location.pathname);
-    }
-  }, [initialFileId]);
+    const handlePopState = () => {
+      setActiveGroup(parseGroupFromPath(window.location.pathname));
+      setActiveFileId(parseFileIdFromSearch(window.location.search));
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
 
   useEffect(() => {
     if (!searchQuery?.trim()) {
@@ -351,21 +364,37 @@ export function App() {
     });
   }, []);
 
-  const handleGroupChange = (name: string) => {
+  const handleGroupChange = useCallback((name: string) => {
+    window.history.pushState(null, "", groupToPath(name));
     setActiveGroup(name);
     setActiveFileId(null);
-    window.history.pushState(null, "", groupToPath(name));
-  };
-
-  const handleFileOpened = useCallback((fileId: string) => {
-    setActiveFileId(fileId);
-    setPendingSearchHeading(null);
   }, []);
 
-  const handleSearchResultSelect = useCallback((fileId: string, heading?: string) => {
-    setActiveFileId(fileId);
-    setPendingSearchHeading(heading || null);
-  }, []);
+  const handleFileSelect = useCallback(
+    (fileId: string) => {
+      window.history.pushState(null, "", buildFileUrl(activeGroup, fileId));
+      setActiveFileId(fileId);
+    },
+    [activeGroup],
+  );
+
+  const handleFileOpened = useCallback(
+    (fileId: string) => {
+      window.history.pushState(null, "", buildFileUrl(activeGroup, fileId));
+      setActiveFileId(fileId);
+      setPendingSearchHeading(null);
+    },
+    [activeGroup],
+  );
+
+  const handleSearchResultSelect = useCallback(
+    (fileId: string, heading?: string) => {
+      window.history.pushState(null, "", buildFileUrl(activeGroup, fileId));
+      setActiveFileId(fileId);
+      setPendingSearchHeading(heading || null);
+    },
+    [activeGroup],
+  );
 
   const handleRemoveFile = useCallback(() => {
     if (activeFileId != null) {
@@ -459,7 +488,7 @@ export function App() {
             groups={groups}
             activeGroup={activeGroup}
             activeFileId={activeFileId}
-            onFileSelect={setActiveFileId}
+            onFileSelect={handleFileSelect}
             onFilesReorder={handleFilesReorder}
             viewMode={currentViewMode}
             showTitle={currentShowTitle}


### PR DESCRIPTION
> [!NOTE]
> This is offered as a starting point for discussion — please feel free to close this PR without hesitation if it does not fit the direction you want for the project.

## Summary

Synchronizes `?file=<id>` in the URL whenever the active file changes. Today, only `handleGroupChange` calls `pushState`; the file-selection paths (`onFileSelect`, search-result selection, Markdown internal links, etc.) update React state but not the URL. Direct-access still works because `parseFileIdFromSearch(window.location.search)` reads `?file=...` on load — but the URL is never written back during a session, so bookmarks, link sharing, and browser back/forward only land on the *group*, not the specific file.

This PR:

- Writes the active file id to the URL across all selection paths.
- Adds a `popstate` listener so browser back/forward and history jumps restore `activeGroup` / `activeFileId`.
- Splits responsibility cleanly: user-initiated selections call `pushState` directly at the call site; automatic syncs (initial load, SSE-driven changes, render-time fallbacks) use `replaceState` so they do not pollute history.

<img width="800" height="399" alt="CleanShot 2026-04-29 at 10 55 38" src="https://github.com/user-attachments/assets/06bd9c16-8eb7-4ff9-bb64-863db366b82b" />

## Why

Without this, several behaviors that users tend to expect from a URL-addressable viewer break in practice:

- WCAG 2.4.5 (Multiple Ways): URL direct-access, bookmarks, and shared links land on the group rather than the chosen file.
- WCAG 3.2.3 / 2.1.1: browser back/forward and history navigation cannot move between files; the only remaining inter-file navigation for keyboard-only users is Tab + Enter through the sidebar one item at a time.

The codebase already has the *read* side of this contract (`parseFileIdFromSearch`); this PR adds the *write* side so the two stay in sync.

## Test plan

- [x] `pnpm test` — 215 passing
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run lint`
- [x] `pnpm run fmt:check`
- [ ] Manual: selecting a file in the Sidebar updates the URL to `?file=<id>`.
- [ ] Manual: browser Back / Forward navigates between previously-viewed files.
- [ ] Manual: the automatic file selection that follows a group switch does *not* add a new history entry (uses `replaceState`).
- [ ] Manual: opening `/?file=<unknown>` falls back to the first file and rewrites the URL.