### PR TITLE
fix(frontend): use <a> for file/heading navigation

### DIFF
--- a/internal/frontend/src/components/MarkdownViewer.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.tsx
@@ -11,6 +11,7 @@ import "katex/dist/katex.min.css";
 import { codeToHtml } from "shiki";
 import mermaid from "mermaid";
 import { fetchFileContent, openRelativeFile } from "../hooks/useApi";
+import { isPlainLeftClick } from "../utils/linkClick";
 import { escapeRegExp } from "../utils/regex";
 import { RawToggle } from "./RawToggle";
 import { TocToggle } from "./TocToggle";
@@ -638,7 +639,7 @@ export function MarkdownViewer({
               <a
                 href={href}
                 onClick={(e) => {
-                  if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                  if (!isPlainLeftClick(e)) return;
                   const id = href?.slice(1);
                   if (!id) return;
                   const target = document.getElementById(id);

--- a/internal/frontend/src/components/Sidebar.test.tsx
+++ b/internal/frontend/src/components/Sidebar.test.tsx
@@ -98,11 +98,13 @@ describe("Sidebar", () => {
         onSearchQueryChange={() => {}}
       />,
     );
-    const activeButton = screen.getByText("README.md").closest("button")!;
-    expect(activeButton.className).toContain("bg-gh-bg-active");
+    const activeLink = screen.getByText("README.md").closest("a")!;
+    expect(activeLink.className).toContain("bg-gh-bg-active");
+    expect(activeLink.getAttribute("aria-current")).toBe("page");
 
-    const inactiveButton = screen.getByText("GUIDE.md").closest("button")!;
-    expect(inactiveButton.className).toContain("bg-transparent");
+    const inactiveLink = screen.getByText("GUIDE.md").closest("a")!;
+    expect(inactiveLink.className).toContain("bg-transparent");
+    expect(inactiveLink.getAttribute("aria-current")).toBeNull();
   });
 
   it("calls onFileSelect when a file is clicked", async () => {
@@ -124,6 +126,49 @@ describe("Sidebar", () => {
 
     await user.click(screen.getByText("GUIDE.md"));
     expect(onFileSelect).toHaveBeenCalledWith("bbb22222");
+  });
+
+  it("renders file items as anchors with href to file URL", () => {
+    render(
+      <Sidebar
+        groups={groups}
+        activeGroup="default"
+        activeFileId={null}
+        onFileSelect={() => {}}
+        onFilesReorder={() => {}}
+        viewMode="flat"
+        showTitle={false}
+        searchQuery={null}
+        onSearchQueryChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("README.md").closest("a")?.getAttribute("href")).toBe(
+      "/?file=aaa11111",
+    );
+    expect(screen.getByText("GUIDE.md").closest("a")?.getAttribute("href")).toBe("/?file=bbb22222");
+  });
+
+  it("does not call onFileSelect when modifier keys are pressed", async () => {
+    const user = userEvent.setup();
+    const onFileSelect = vi.fn();
+    render(
+      <Sidebar
+        groups={groups}
+        activeGroup="default"
+        activeFileId={null}
+        onFileSelect={onFileSelect}
+        onFilesReorder={() => {}}
+        viewMode="flat"
+        showTitle={false}
+        searchQuery={null}
+        onSearchQueryChange={() => {}}
+      />,
+    );
+
+    await user.keyboard("[ControlLeft>]");
+    await user.click(screen.getByText("GUIDE.md"));
+    await user.keyboard("[/ControlLeft]");
+    expect(onFileSelect).not.toHaveBeenCalled();
   });
 
   it("shows file path as title attribute", () => {

--- a/internal/frontend/src/components/Sidebar.tsx
+++ b/internal/frontend/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ import { CSS } from "@dnd-kit/utilities";
 import type { FileEntry, Group, SearchResult } from "../hooks/useApi";
 import { removeFile, moveFile } from "../hooks/useApi";
 import { buildFileUrl } from "../utils/groups";
+import { isPlainLeftClick } from "../utils/linkClick";
 import { escapeRegExp } from "../utils/regex";
 import type { ViewMode } from "./ViewModeToggle";
 import { TreeView } from "./TreeView";
@@ -56,6 +57,7 @@ function renderHighlightedText(text: string, query: string) {
 
 interface FileItemProps {
   file: FileEntry;
+  activeGroup: string;
   isActive: boolean;
   showTitle: boolean;
   menuOpenId: string | null;
@@ -72,6 +74,7 @@ interface FileItemProps {
 
 function FileItem({
   file,
+  activeGroup,
   isActive,
   showTitle,
   menuOpenId,
@@ -87,20 +90,26 @@ function FileItem({
 }: FileItemProps) {
   return (
     <div className="relative group/file">
-      <button
-        className={`flex items-center gap-2 w-full px-3 py-2 border-none cursor-pointer text-left text-sm transition-colors duration-150 ${
+      <a
+        href={buildFileUrl(activeGroup, file.id)}
+        className={`flex items-center gap-2 w-full px-3 py-2 border-none cursor-pointer text-left text-sm no-underline transition-colors duration-150 ${
           isActive
             ? "bg-gh-bg-active text-gh-text font-semibold"
             : "bg-transparent text-gh-text-secondary hover:bg-gh-bg-hover"
         }`}
-        onClick={() => onFileSelect(file.id)}
+        onClick={(e) => {
+          if (!isPlainLeftClick(e)) return;
+          e.preventDefault();
+          onFileSelect(file.id);
+        }}
         title={file.uploaded ? file.name : file.path}
+        aria-current={isActive ? "page" : undefined}
       >
         <FileIcon uploaded={file.uploaded} />
         <span className="overflow-hidden text-ellipsis whitespace-nowrap pr-6">
           {(showTitle && file.title) || file.name}
         </span>
-      </button>
+      </a>
       <FileContextMenu
         file={file}
         isOpen={menuOpenId === file.id}
@@ -356,11 +365,15 @@ export function Sidebar({
                 {contentMatchesOpen &&
                   searchResults.flatMap((result) =>
                     result.matches.map((match, index) => (
-                      <button
+                      <a
                         key={`${result.fileId}:${match.line}:${index}`}
-                        type="button"
-                        className="w-full px-3 py-2 text-left border-none bg-transparent cursor-pointer transition-colors duration-150 hover:bg-gh-bg-hover"
-                        onClick={() => onSearchResultSelect?.(result.fileId, match.heading)}
+                        href={buildFileUrl(activeGroup, result.fileId)}
+                        className="w-full px-3 py-2 text-left border-none bg-transparent cursor-pointer no-underline text-gh-text-secondary transition-colors duration-150 hover:bg-gh-bg-hover"
+                        onClick={(e) => {
+                          if (!isPlainLeftClick(e)) return;
+                          e.preventDefault();
+                          onSearchResultSelect?.(result.fileId, match.heading);
+                        }}
                       >
                         <div className="flex items-center gap-2 text-sm font-medium text-gh-text">
                           <FileIcon uploaded={result.uploaded} />
@@ -390,7 +403,7 @@ export function Sidebar({
                             </div>
                           ))}
                         </div>
-                      </button>
+                      </a>
                     )),
                   )}
               </>
@@ -411,6 +424,7 @@ export function Sidebar({
                     <FileItem
                       key={f.id}
                       file={f}
+                      activeGroup={activeGroup}
                       isActive={f.id === activeFileId}
                       showTitle={showTitle}
                       menuOpenId={menuOpenId}
@@ -459,6 +473,7 @@ export function Sidebar({
                 <SortableFileItem
                   key={f.id}
                   file={f}
+                  activeGroup={activeGroup}
                   isActive={f.id === activeFileId}
                   showTitle={showTitle}
                   menuOpenId={menuOpenId}

--- a/internal/frontend/src/components/TocPanel.test.tsx
+++ b/internal/frontend/src/components/TocPanel.test.tsx
@@ -31,12 +31,14 @@ describe("TocPanel", () => {
 
   it("highlights the active heading", () => {
     render(<TocPanel headings={headings} activeHeadingId="setup" onHeadingClick={() => {}} />);
-    const activeButton = screen.getByText("Setup").closest("button")!;
-    expect(activeButton.className).toContain("bg-gh-bg-active");
-    expect(activeButton.className).toContain("font-semibold");
+    const activeLink = screen.getByText("Setup").closest("a")!;
+    expect(activeLink.className).toContain("bg-gh-bg-active");
+    expect(activeLink.className).toContain("font-semibold");
+    expect(activeLink.getAttribute("aria-current")).toBe("location");
 
-    const inactiveButton = screen.getByText("Introduction").closest("button")!;
-    expect(inactiveButton.className).toContain("bg-transparent");
+    const inactiveLink = screen.getByText("Introduction").closest("a")!;
+    expect(inactiveLink.className).toContain("bg-transparent");
+    expect(inactiveLink.getAttribute("aria-current")).toBeNull();
   });
 
   it("calls onHeadingClick with the heading id", async () => {
@@ -48,15 +50,21 @@ describe("TocPanel", () => {
     expect(onHeadingClick).toHaveBeenCalledWith("config");
   });
 
+  it("renders each heading as a link with hash href", () => {
+    render(<TocPanel headings={headings} activeHeadingId={null} onHeadingClick={() => {}} />);
+    expect(screen.getByText("Introduction").closest("a")?.getAttribute("href")).toBe("#intro");
+    expect(screen.getByText("Setup").closest("a")?.getAttribute("href")).toBe("#setup");
+  });
+
   it("applies different indentation per heading level", () => {
     render(<TocPanel headings={headings} activeHeadingId={null} onHeadingClick={() => {}} />);
-    const h1Button = screen.getByText("Introduction").closest("button")!;
-    const h2Button = screen.getByText("Setup").closest("button")!;
-    const h3Button = screen.getByText("Configuration").closest("button")!;
+    const h1Link = screen.getByText("Introduction").closest("a")!;
+    const h2Link = screen.getByText("Setup").closest("a")!;
+    const h3Link = screen.getByText("Configuration").closest("a")!;
 
-    expect(h1Button.className).toContain("pl-3");
-    expect(h2Button.className).toContain("pl-6");
-    expect(h3Button.className).toContain("pl-9");
+    expect(h1Link.className).toContain("pl-3");
+    expect(h2Link.className).toContain("pl-6");
+    expect(h3Link.className).toContain("pl-9");
   });
 
   it("shows heading text as title attribute", () => {

--- a/internal/frontend/src/components/TocPanel.tsx
+++ b/internal/frontend/src/components/TocPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { isPlainLeftClick } from "../utils/linkClick";
 
 export interface TocHeading {
   id: string;
@@ -85,18 +86,24 @@ export function TocPanel({ headings, activeHeadingId, onHeadingClick }: TocPanel
           <div className="px-3 py-2 text-gh-text-secondary text-sm">No headings</div>
         ) : (
           headings.map((h) => (
-            <button
+            <a
               key={h.id}
-              className={`flex items-center w-full ${INDENT[h.level] ?? "pl-3"} pr-3 py-1.5 border-none cursor-pointer text-left text-sm transition-colors duration-150 ${
+              href={`#${h.id}`}
+              className={`flex items-center w-full ${INDENT[h.level] ?? "pl-3"} pr-3 py-1.5 border-none cursor-pointer text-left text-sm no-underline transition-colors duration-150 ${
                 h.id === activeHeadingId
                   ? "bg-gh-bg-active text-gh-text font-semibold"
                   : "bg-transparent text-gh-text-secondary hover:bg-gh-bg-hover"
               }`}
-              onClick={() => onHeadingClick(h.id)}
+              onClick={(e) => {
+                if (!isPlainLeftClick(e)) return;
+                e.preventDefault();
+                onHeadingClick(h.id);
+              }}
               title={h.text}
+              aria-current={h.id === activeHeadingId ? "location" : undefined}
             >
               <span className="overflow-hidden text-ellipsis whitespace-nowrap">{h.text}</span>
-            </button>
+            </a>
           ))
         )}
       </nav>

--- a/internal/frontend/src/components/TreeView.tsx
+++ b/internal/frontend/src/components/TreeView.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { FileEntry, Group } from "../hooks/useApi";
 import { buildTree, type TreeNode } from "../utils/buildTree";
+import { buildFileUrl } from "../utils/groups";
+import { isPlainLeftClick } from "../utils/linkClick";
 import { FileContextMenu } from "./FileContextMenu";
 import { FileIcon } from "./FileIcon";
 
@@ -93,6 +95,7 @@ export function TreeView({
           key={node.fullPath}
           node={node}
           depth={0}
+          activeGroup={activeGroup}
           activeFileId={activeFileId}
           showTitle={showTitle}
           menuOpenId={menuOpenId}
@@ -116,6 +119,7 @@ export function TreeView({
 interface TreeNodeItemProps {
   node: TreeNode;
   depth: number;
+  activeGroup: string;
   activeFileId: string | null;
   showTitle: boolean;
   menuOpenId: string | null;
@@ -135,6 +139,7 @@ interface TreeNodeItemProps {
 function TreeNodeItem({
   node,
   depth,
+  activeGroup,
   activeFileId,
   showTitle,
   menuOpenId,
@@ -156,6 +161,7 @@ function TreeNodeItem({
         file={node.file}
         name={node.name}
         depth={depth}
+        activeGroup={activeGroup}
         activeFileId={activeFileId}
         showTitle={showTitle}
         menuOpenId={menuOpenId}
@@ -205,6 +211,7 @@ function TreeNodeItem({
             key={child.fullPath}
             node={child}
             depth={depth + 1}
+            activeGroup={activeGroup}
             activeFileId={activeFileId}
             showTitle={showTitle}
             menuOpenId={menuOpenId}
@@ -229,6 +236,7 @@ interface FileNodeItemProps {
   file: FileEntry;
   name: string;
   depth: number;
+  activeGroup: string;
   activeFileId: string | null;
   showTitle: boolean;
   menuOpenId: string | null;
@@ -247,6 +255,7 @@ function FileNodeItem({
   file,
   name,
   depth,
+  activeGroup,
   activeFileId,
   showTitle,
   menuOpenId,
@@ -264,21 +273,27 @@ function FileNodeItem({
 
   return (
     <div className="relative group/file">
-      <button
-        className={`flex items-center gap-2 w-full px-3 py-2 border-none cursor-pointer text-left text-sm transition-colors duration-150 ${
+      <a
+        href={buildFileUrl(activeGroup, file.id)}
+        className={`flex items-center gap-2 w-full px-3 py-2 border-none cursor-pointer text-left text-sm no-underline transition-colors duration-150 ${
           isActive
             ? "bg-gh-bg-active text-gh-text font-semibold"
             : "bg-transparent text-gh-text-secondary hover:bg-gh-bg-hover"
         }`}
         style={{ paddingLeft: `${depth * 16 + 12}px` }}
-        onClick={() => onFileSelect(file.id)}
+        onClick={(e) => {
+          if (!isPlainLeftClick(e)) return;
+          e.preventDefault();
+          onFileSelect(file.id);
+        }}
         title={file.uploaded ? file.name : file.path}
+        aria-current={isActive ? "page" : undefined}
       >
         <FileIcon uploaded={file.uploaded} />
         <span className="overflow-hidden text-ellipsis whitespace-nowrap pr-6">
           {(showTitle && file.title) || name}
         </span>
-      </button>
+      </a>
       <FileContextMenu
         file={file}
         isOpen={menuOpenId === file.id}

--- a/internal/frontend/src/utils/linkClick.test.ts
+++ b/internal/frontend/src/utils/linkClick.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import type { MouseEvent } from "react";
+import { isPlainLeftClick } from "./linkClick";
+
+function event(overrides: Partial<MouseEvent> = {}): MouseEvent {
+  return {
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...overrides,
+  } as MouseEvent;
+}
+
+describe("isPlainLeftClick", () => {
+  it("returns true for a left-click without modifiers", () => {
+    expect(isPlainLeftClick(event())).toBe(true);
+  });
+
+  it("returns false for non-primary buttons", () => {
+    expect(isPlainLeftClick(event({ button: 1 }))).toBe(false);
+    expect(isPlainLeftClick(event({ button: 2 }))).toBe(false);
+  });
+
+  it.each([["metaKey"], ["ctrlKey"], ["shiftKey"], ["altKey"]] as const)(
+    "returns false when %s is held",
+    (key) => {
+      expect(isPlainLeftClick(event({ [key]: true }))).toBe(false);
+    },
+  );
+});

--- a/internal/frontend/src/utils/linkClick.ts
+++ b/internal/frontend/src/utils/linkClick.ts
@@ -1,0 +1,5 @@
+import type { MouseEvent } from "react";
+
+export function isPlainLeftClick(e: MouseEvent): boolean {
+  return e.button === 0 && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey;
+}


### PR DESCRIPTION
> [!NOTE]
> This is offered as a starting point for discussion — please feel free to close this PR without hesitation if it does not fit the direction you want for the project.

## Summary

Renders the sidebar file items, `TreeView` nodes, `TocPanel` headings, and search content matches as `<a href={...}>` instead of `<button>`, so browser-native link affordances become available.

After this change:

- Cmd/Ctrl+Click and middle-click open the target in a new tab without any custom handler.
- The right-click "Open in new tab" / "Copy link address" menu items work.
- Hovering or focusing the link shows the destination URL in the browser status bar.
- Screen readers announce "link" instead of "button", which matches the actual semantics — these elements are navigation targets, not actions.

The body links inside `MarkdownViewer.tsx` are already `<a>`, so this change also makes sidebar / TOC navigation consistent with how Markdown-internal links already behave.

### Screenshots

In Japanese, sorry.

| Before | After |
|-- |-- |
|<img width="460" height="360" alt="CleanShot 2026-04-29 at 11 00 44" src="https://github.com/user-attachments/assets/d33860f5-7986-4ddb-8ee8-c393271c9ca2" /> |<img width="475" height="240" alt="CleanShot 2026-04-29 at 11 01 13" src="https://github.com/user-attachments/assets/34f43664-8330-427d-ad3f-2e2867e2264c" /> |

### Implementation notes

Each navigation element follows the modifier-key passthrough pattern that `MarkdownViewer.tsx` already uses for hash links:

```tsx
onClick={(e) => {
  if (!isPlainLeftClick(e)) return;
  e.preventDefault();
  onFileSelect(file.id);
}}
```

A plain left-click calls `preventDefault()` and updates internal state in-place. Modifier-clicks and middle-clicks are *not* prevented, so the browser handles them natively. Active items get `aria-current="page"` (files) or `aria-current="location"` (headings).

### WCAG references

- 4.1.2 (Name, Role, Value): elements are now announced as links, matching their semantics.
- 3.2.4 (Consistent Identification): file / heading navigation now matches body-link behavior elsewhere in the viewer.
- 2.5.6 (Concurrent Input Mechanisms) / 2.1.1: middle-click, Cmd/Ctrl+Click, "Open in new tab", and copy-link become standard browser features rather than features only reachable through the kebab menu.

## Test plan

- [x] `pnpm test --run` — 219 passing (+6 new tests: `isPlainLeftClick` unit tests, plus anchor-rendering and modifier-click tests for `Sidebar` and `TocPanel`).
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run lint` — 0 warnings, 0 errors
- [x] `pnpm run fmt:check`
- [ ] Manual: a plain click switches the active file as before.
- [ ] Manual: Cmd/Ctrl+Click opens the file in a new tab.
- [ ] Manual: middle-click opens the file in a new tab.
- [ ] Manual: focusing a sidebar item via Tab shows the destination URL in the browser status bar.