### PR TITLE
fix: drop missing files from state when content fetch hits ENOENT

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -475,6 +475,44 @@ func (s *State) MoveFile(id, sourceGroupName, targetGroup string) error {
 	return nil
 }
 
+// RemoveFilesByPath removes every file entry whose path matches absPath across
+// all groups, cleans up the watcher, and drops any groups left empty without
+// patterns. Returns true if at least one entry was removed.
+func (s *State) RemoveFilesByPath(absPath string) bool {
+	if absPath == "" {
+		return false
+	}
+
+	s.mu.Lock()
+	removed := false
+	for name, g := range s.groups {
+		filtered := g.Files[:0]
+		for _, f := range g.Files {
+			if f.Path == absPath {
+				removed = true
+				slog.Info("file removed", "path", f.Path, "id", f.ID, "group", name) //nolint:gosec // G706: structured logging fields, no injection risk
+				continue
+			}
+			filtered = append(filtered, f)
+		}
+		g.Files = filtered
+		if len(g.Files) == 0 && !s.groupHasPatterns(name) {
+			delete(s.groups, name)
+		}
+	}
+	if removed && s.watcher != nil {
+		if err := s.watcher.Remove(absPath); err != nil {
+			slog.Warn("failed to unwatch file", "path", absPath, "error", err)
+		}
+	}
+	s.mu.Unlock()
+
+	if removed {
+		s.sendEvent(sseEvent{Name: eventUpdate, Data: "{}"})
+	}
+	return removed
+}
+
 func (s *State) RemoveFile(id, groupName string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1451,6 +1489,13 @@ func handleFileContent(state *State) http.HandlerFunc {
 		} else {
 			content, err := os.ReadFile(entry.Path) //nolint:gosec // Path is server-managed, not user-supplied
 			if err != nil {
+				if os.IsNotExist(err) {
+					// File is gone from disk: drop it from state so the group
+					// (and possibly the group itself) disappears from the UI.
+					state.RemoveFilesByPath(entry.Path)
+					http.Error(w, "file not found", http.StatusNotFound)
+					return
+				}
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -495,6 +495,11 @@ func (s *State) RemoveFilesByPath(absPath string) bool {
 			}
 			filtered = append(filtered, f)
 		}
+		// Clear the truncated tail so removed *FileEntry pointers don't linger
+		// in the backing array and block GC.
+		for i := len(filtered); i < len(g.Files); i++ {
+			g.Files[i] = nil
+		}
 		g.Files = filtered
 		if len(g.Files) == 0 && !s.groupHasPatterns(name) {
 			delete(s.groups, name)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1964,6 +1964,71 @@ func TestRemoveFileNotFound(t *testing.T) {
 	}
 }
 
+func TestHandleFileContent_RemovesEntryWhenFileMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "ghost.md")
+	if err := os.WriteFile(path, []byte("# Ghost"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newTestState(t)
+	entry, err := s.AddFile(path, DefaultGroup)
+	if err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewHandler(s)
+	req := httptest.NewRequest("GET", fmt.Sprintf("/_/api/groups/default/files/%s/content", entry.ID), nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusNotFound)
+	}
+
+	if groups := s.Groups(); len(groups) != 0 {
+		t.Fatalf("expected group to be removed after missing file fetch, got %d groups", len(groups))
+	}
+}
+
+func TestRemoveFilesByPath_RemovesAcrossGroupsAndCleansEmptyGroups(t *testing.T) {
+	tmpDir := t.TempDir()
+	pathA := filepath.Join(tmpDir, "shared.md")
+	pathB := filepath.Join(tmpDir, "other.md")
+	for _, p := range []string{pathA, pathB} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s := newTestState(t)
+	if _, err := s.AddFile(pathA, DefaultGroup); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AddFile(pathA, "other"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AddFile(pathB, "other"); err != nil {
+		t.Fatal(err)
+	}
+
+	if !s.RemoveFilesByPath(pathA) {
+		t.Fatal("RemoveFilesByPath returned false")
+	}
+
+	groups := s.Groups()
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group remaining (default should be empty and dropped), got %d", len(groups))
+	}
+	if groups[0].Name != "other" || len(groups[0].Files) != 1 || groups[0].Files[0].Path != pathB {
+		t.Fatalf("unexpected remaining group state: %+v", groups[0])
+	}
+}
+
 func TestHandleOpenFile_PercentEncodedNonASCII(t *testing.T) {
 	// Create a temp directory with a non-ASCII markdown file
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary

- Fix the lingering sidebar entry that shows "Failed to load file." after a file is deleted from disk while the server is running (fsnotify can miss the Remove event on macOS).
- When `os.ReadFile` in `handleFileContent` fails with `os.IsNotExist`, call the new `RemoveFilesByPath` to drop every entry referencing that path from all groups; groups left empty without patterns are deleted.
- The watcher entry is also unregistered and an `update` SSE event is emitted so the frontend re-syncs immediately.