### PR TITLE
fix: apply color-scheme dark to root dark theme selector

### DIFF
--- a/internal/frontend/src/styles/app.css
+++ b/internal/frontend/src/styles/app.css
@@ -15,6 +15,7 @@
 }
 
 [data-theme="dark"] {
+  color-scheme: dark;
   --color-gh-bg: #0d1117;
   --color-gh-bg-secondary: #161b22;
   --color-gh-bg-sidebar: #161b22;


### PR DESCRIPTION
## Summary

In dark mode, scrollbars in the main content area and TOC panel render with a white background, creating a jarring visual contrast against the dark theme.

## Root cause

`color-scheme: dark` is currently set only on `[data-theme="dark"] .markdown-body` (line 198 of `app.css`). However, the scrollable containers that produce visible scrollbars — the main content area (`overflow-y-auto` in `App.tsx`), the sidebar, and the TOC panel — are outside `.markdown-body`. Since the browser does not see `color-scheme: dark` on these ancestor elements, it renders their native scrollbars in light style.

## Fix

Add `color-scheme: dark` to the root-level `[data-theme="dark"]` selector (line 17 of `app.css`). This makes the browser apply dark styling to all native UI elements (scrollbars, form controls, etc.) within the entire dark-themed subtree.

The existing `color-scheme: dark` on `.markdown-body` becomes redundant but is left in place to keep the diff minimal.

## Test plan

- [x] Switch to dark mode - scrollbars on main content area and TOC panel match the dark background
- [x] Switch back to light mode - scrollbars revert to default light style
- [x] Print preview remains unaffected (scrollbars hidden via existing `@media print` rules)