### PR TITLE
refactor(frontend): hoist color-scheme to root theme selectors

### DIFF
--- a/internal/frontend/src/styles/app.css
+++ b/internal/frontend/src/styles/app.css
@@ -14,6 +14,10 @@
   --color-gh-header-border: #d0d7de;
 }
 
+[data-theme="light"] {
+  color-scheme: light;
+}
+
 [data-theme="dark"] {
   color-scheme: dark;
   --color-gh-bg: #0d1117;
@@ -76,7 +80,6 @@ body,
 }
 
 [data-theme="light"] .markdown-body {
-  color-scheme: light;
   --fgColor-accent: #0969da;
   --fgColor-danger: #d1242f;
   --fgColor-default: #1f2328;
@@ -196,7 +199,6 @@ body,
 }
 
 [data-theme="dark"] .markdown-body {
-  color-scheme: dark;
   --fgColor-accent: #4493f8;
   --fgColor-danger: #f85149;
   --fgColor-default: #f0f6fc;


### PR DESCRIPTION
## Summary

- Follow-up to #201. Move `color-scheme: light/dark` from `.markdown-body` up to the root `[data-theme="light"]` / `[data-theme="dark"]` selectors so the value is set once and inherits everywhere.
- Adds a new `[data-theme="light"]` block (none existed before, since the light values lived in `@theme {}`) so light mode is symmetric with dark and unaffected by the OS's preferred color scheme.
- Drops the now-redundant `color-scheme` declarations from the two `.markdown-body` rules.