### PR TITLE
chore: migrate from fsnotify/fsnotify to gofsnotify/fsnotify

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -86,34 +86,237 @@ SOFTWARE.
 
 ================================================================
 
-github.com/fsnotify/fsnotify
-https://github.com/fsnotify/fsnotify
+github.com/ebitengine/purego
+https://github.com/ebitengine/purego
 ----------------------------------------------------------------
-Copyright © 2012 The Go Authors. All rights reserved.
-Copyright © fsnotify Authors. All rights reserved.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice, this
-  list of conditions and the following disclaimer in the documentation and/or
-  other materials provided with the distribution.
-* Neither the name of Google Inc. nor the names of its contributors may be used
-  to endorse or promote products derived from this software without specific
-  prior written permission.
+   1. Definitions.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+================================================================
+
+github.com/gofsnotify/fsnotify
+https://github.com/gofsnotify/fsnotify
+----------------------------------------------------------------
+MIT License
+
+Copyright (c) 2026 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ================================================================
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
-	github.com/fsnotify/fsnotify v1.10.0
+	github.com/gofsnotify/fsnotify v0.0.4
 	github.com/k1LoW/donegroup v1.10.3
 	github.com/k1LoW/errors v1.2.0
 	github.com/muesli/termenv v0.16.0
@@ -15,6 +15,7 @@ require (
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,10 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/fsnotify/fsnotify v1.10.0 h1:Xx/5Ydg9CeBDX/wi4VJqStNtohYjitZhhlHt4h3St1M=
-github.com/fsnotify/fsnotify v1.10.0/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
+github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
+github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/gofsnotify/fsnotify v0.0.4 h1:RuJQe7852TsOfRVOgLcs5ej36LPmL9zRvsmTlpY/a/8=
+github.com/gofsnotify/fsnotify v0.0.4/go.mod h1:2ABUH3E+Z40JVdAwCeNFKIvKSZF6NcnEH9BUN3/GmG8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/k1LoW/donegroup v1.10.3 h1:+FPxE8MSxgqsdkxj8Y8hfFF1rHooh04pdl1441EeylQ=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -293,7 +293,10 @@ func (s *State) AddFile(absPath, groupName string) (*FileEntry, error) {
 	}
 
 	title := extractTitle(string(head))
-	canonical := resolvePathAlias(absPath)
+	var canonical string
+	if s.watcher != nil {
+		canonical = resolvePathAlias(absPath)
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -200,6 +200,10 @@ type State struct {
 	// our state keeps the user-facing form (/var/...). This mapping lets
 	// the watch loop translate event paths back to their stored keys.
 	pathAliases map[string]string
+	// aliasReverse maps the original path to its canonical form, so an
+	// entry can be removed without re-running EvalSymlinks (which would
+	// fail once the underlying file or directory is gone).
+	aliasReverse map[string]string
 
 	fileChangeDebounce time.Duration
 	fileChangeTimers   map[string]*time.Timer
@@ -225,6 +229,7 @@ func NewState(ctx context.Context) *State {
 		shutdownCh:         make(chan struct{}, 1),
 		watchedDirs:        make(map[string]int),
 		pathAliases:        make(map[string]string),
+		aliasReverse:       make(map[string]string),
 		fileChangeDebounce: defaultFileChangeDebounce,
 		fileChangeTimers:   make(map[string]*time.Timer),
 	}
@@ -522,6 +527,7 @@ func (s *State) RemoveFilesByPath(absPath string) bool {
 		if err := s.watcher.Remove(absPath); err != nil {
 			slog.Warn("failed to unwatch file", "path", absPath, "error", err)
 		}
+		s.unregisterPathAlias(absPath)
 	}
 	s.mu.Unlock()
 
@@ -574,6 +580,7 @@ func (s *State) RemoveFile(id, groupName string) bool {
 			if err := s.watcher.Remove(removedPath); err != nil {
 				slog.Warn("failed to unwatch file", "path", removedPath, "error", err)
 			}
+			s.unregisterPathAlias(removedPath)
 		}
 	}
 
@@ -931,6 +938,7 @@ func (s *State) removeDirWatch(dir string) {
 					slog.Warn("failed to remove directory watch", "dir", dir, "error", err)
 				}
 			}
+			s.unregisterPathAlias(dir)
 		} else {
 			s.watchedDirs[dir] = count
 		}
@@ -1071,6 +1079,18 @@ func (s *State) registerPathAlias(orig string) {
 		return
 	}
 	s.pathAliases[canonical] = orig
+	s.aliasReverse[orig] = canonical
+}
+
+// unregisterPathAlias removes any alias previously registered for orig.
+// Caller must hold s.mu for write.
+func (s *State) unregisterPathAlias(orig string) {
+	canonical, ok := s.aliasReverse[orig]
+	if !ok {
+		return
+	}
+	delete(s.pathAliases, canonical)
+	delete(s.aliasReverse, orig)
 }
 
 // translateEventPath returns the stored form of an event path when the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1204,17 +1204,31 @@ func (s *State) watchDirsForPattern(gp *GlobPattern) {
 }
 
 func (s *State) addDirWatch(dir string) {
-	canonical := resolvePathAlias(dir)
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.watchedDirs[dir]++
+	added := false
 	if s.watchedDirs[dir] == 1 && s.watcher != nil {
 		if err := s.watcher.Add(dir, watchOps); err != nil {
 			delete(s.watchedDirs, dir)
 			slog.Warn("failed to watch directory", "path", dir, "error", err)
 		} else {
-			s.registerPathAlias(dir, canonical)
+			added = true
 		}
+	}
+	s.mu.Unlock()
+
+	if !added {
+		return
+	}
+
+	canonical := resolvePathAlias(dir)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Register the alias only if the directory is still being watched: a
+	// concurrent removeDirWatch may have dropped it during the unlock window.
+	if _, stillWatched := s.watchedDirs[dir]; stillWatched {
+		s.registerPathAlias(dir, canonical)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
-	"github.com/fsnotify/fsnotify"
+	"github.com/gofsnotify/fsnotify"
 	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/mo/internal/static"
 	"github.com/k1LoW/mo/version"
@@ -167,6 +167,10 @@ const (
 	eventFileChanged = "file-changed"
 )
 
+// watchOps is the set of fsnotify ops the watch loop reacts to.
+// Chmod is intentionally excluded because the loop ignores it.
+const watchOps = fsnotify.Create | fsnotify.Write | fsnotify.Remove | fsnotify.Rename
+
 // GlobPattern represents a glob pattern being watched for new files.
 type GlobPattern struct {
 	Pattern      string // Absolute glob pattern
@@ -190,6 +194,12 @@ type State struct {
 	shutdownCh  chan struct{}
 	patterns    []*GlobPattern
 	watchedDirs map[string]int // directory → reference count
+	// pathAliases maps a canonical (symlink-resolved) path back to the
+	// original path we stored. The fsnotify watcher canonicalizes paths,
+	// so events arrive with the resolved form (e.g. /private/var/...) while
+	// our state keeps the user-facing form (/var/...). This mapping lets
+	// the watch loop translate event paths back to their stored keys.
+	pathAliases map[string]string
 
 	fileChangeDebounce time.Duration
 	fileChangeTimers   map[string]*time.Timer
@@ -214,6 +224,7 @@ func NewState(ctx context.Context) *State {
 		restartCh:          make(chan string, 1),
 		shutdownCh:         make(chan struct{}, 1),
 		watchedDirs:        make(map[string]int),
+		pathAliases:        make(map[string]string),
 		fileChangeDebounce: defaultFileChangeDebounce,
 		fileChangeTimers:   make(map[string]*time.Timer),
 	}
@@ -303,8 +314,10 @@ func (s *State) AddFile(absPath, groupName string) (*FileEntry, error) {
 	g.Files = append(g.Files, entry)
 
 	if s.watcher != nil {
-		if err := s.watcher.Add(absPath); err != nil {
+		if err := s.watcher.Add(absPath, watchOps); err != nil {
 			slog.Warn("failed to watch file", "path", absPath, "error", err)
+		} else {
+			s.registerPathAlias(absPath)
 		}
 	}
 
@@ -931,35 +944,36 @@ func (s *State) watchLoop() {
 			if !ok {
 				return
 			}
-			refs := s.findRefsByPath(event.Name)
+			eventPath := s.translateEventPath(event.Name)
+			refs := s.findRefsByPath(eventPath)
 			if len(refs) > 0 {
-				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
-					slog.Info("file changed", "path", event.Name)
-					s.scheduleFileChanged(event.Name)
+				if event.Op.Has(fsnotify.Write) || event.Op.Has(fsnotify.Create) {
+					slog.Info("file changed", "path", eventPath)
+					s.scheduleFileChanged(eventPath)
 				}
 				// Editors using atomic save (write-to-temp + rename) cause
 				// the original inode to disappear, which removes the watch.
 				// Re-add the watch so subsequent saves are still detected.
-				if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+				if event.Op.Has(fsnotify.Remove) || event.Op.Has(fsnotify.Rename) {
 					time.AfterFunc(100*time.Millisecond, func() {
-						if err := s.watcher.Add(event.Name); err != nil {
+						if err := s.watcher.Add(eventPath, watchOps); err != nil {
 							// File is actually gone — remove from file list
-							slog.Info("file deleted, removing from list", "path", event.Name)
+							slog.Info("file deleted, removing from list", "path", eventPath)
 							for _, ref := range refs {
 								s.RemoveFile(ref.ID, ref.Group)
 							}
 						} else {
-							slog.Info("re-watching file", "path", event.Name)
-							s.scheduleFileChanged(event.Name)
+							slog.Info("re-watching file", "path", eventPath)
+							s.scheduleFileChanged(eventPath)
 						}
 					})
 				}
 			}
-			if (event.Has(fsnotify.Rename) || event.Has(fsnotify.Remove)) && s.isWatchedDir(event.Name) {
-				s.handleDirMove(event.Name)
+			if (event.Op.Has(fsnotify.Rename) || event.Op.Has(fsnotify.Remove)) && s.isWatchedDir(eventPath) {
+				s.handleDirMove(eventPath)
 			}
-			if event.Has(fsnotify.Create) {
-				s.handleCreateForGlobs(event.Name)
+			if event.Op.Has(fsnotify.Create) {
+				s.handleCreateForGlobs(eventPath)
 			}
 		case err, ok := <-s.watcher.Errors:
 			if !ok {
@@ -1048,6 +1062,28 @@ type fileRef struct {
 	Group string
 }
 
+// registerPathAlias records the canonical (symlink-resolved) form of orig
+// so watcher events can be mapped back to the stored path. Caller must hold
+// s.mu for write.
+func (s *State) registerPathAlias(orig string) {
+	canonical, err := filepath.EvalSymlinks(orig)
+	if err != nil || canonical == orig {
+		return
+	}
+	s.pathAliases[canonical] = orig
+}
+
+// translateEventPath returns the stored form of an event path when the
+// watcher reported a canonicalized variant; otherwise it returns p as-is.
+func (s *State) translateEventPath(p string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if orig, ok := s.pathAliases[p]; ok {
+		return orig
+	}
+	return p
+}
+
 func (s *State) findRefsByPath(absPath string) []fileRef {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1119,9 +1155,11 @@ func (s *State) addDirWatch(dir string) {
 	defer s.mu.Unlock()
 	s.watchedDirs[dir]++
 	if s.watchedDirs[dir] == 1 && s.watcher != nil {
-		if err := s.watcher.Add(dir); err != nil {
+		if err := s.watcher.Add(dir, watchOps); err != nil {
 			delete(s.watchedDirs, dir)
 			slog.Warn("failed to watch directory", "path", dir, "error", err)
+		} else {
+			s.registerPathAlias(dir)
 		}
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -293,6 +293,7 @@ func (s *State) AddFile(absPath, groupName string) (*FileEntry, error) {
 	}
 
 	title := extractTitle(string(head))
+	canonical := resolvePathAlias(absPath)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -322,7 +323,7 @@ func (s *State) AddFile(absPath, groupName string) (*FileEntry, error) {
 		if err := s.watcher.Add(absPath, watchOps); err != nil {
 			slog.Warn("failed to watch file", "path", absPath, "error", err)
 		} else {
-			s.registerPathAlias(absPath)
+			s.registerPathAlias(absPath, canonical)
 		}
 	}
 
@@ -1070,12 +1071,23 @@ type fileRef struct {
 	Group string
 }
 
-// registerPathAlias records the canonical (symlink-resolved) form of orig
-// so watcher events can be mapped back to the stored path. Caller must hold
-// s.mu for write.
-func (s *State) registerPathAlias(orig string) {
+// resolvePathAlias returns the canonical (symlink-resolved) form of orig
+// when it differs from orig, or "" otherwise. Performs filesystem I/O, so
+// callers should invoke it outside any critical section.
+func resolvePathAlias(orig string) string {
 	canonical, err := filepath.EvalSymlinks(orig)
 	if err != nil || canonical == orig {
+		return ""
+	}
+	return canonical
+}
+
+// registerPathAlias records canonical → orig (and the reverse) so watcher
+// events can be mapped back to the stored path. canonical must be the
+// pre-resolved value returned by resolvePathAlias. Caller must hold s.mu
+// for write.
+func (s *State) registerPathAlias(orig, canonical string) {
+	if canonical == "" {
 		return
 	}
 	s.pathAliases[canonical] = orig
@@ -1189,6 +1201,7 @@ func (s *State) watchDirsForPattern(gp *GlobPattern) {
 }
 
 func (s *State) addDirWatch(dir string) {
+	canonical := resolvePathAlias(dir)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.watchedDirs[dir]++
@@ -1197,7 +1210,7 @@ func (s *State) addDirWatch(dir string) {
 			delete(s.watchedDirs, dir)
 			slog.Warn("failed to watch directory", "path", dir, "error", err)
 		} else {
-			s.registerPathAlias(dir)
+			s.registerPathAlias(dir, canonical)
 		}
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1081,7 +1081,25 @@ func (s *State) translateEventPath(p string) string {
 	if orig, ok := s.pathAliases[p]; ok {
 		return orig
 	}
-	return p
+	// Files created inside a watched (symlinked) directory arrive with the
+	// canonical path of that directory as a prefix, but only the directory
+	// itself has an alias entry. Walk up parents to find the closest alias
+	// and rebuild the path with the original prefix.
+	dir := p
+	for {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return p
+		}
+		dir = parent
+		if orig, ok := s.pathAliases[dir]; ok {
+			rel, err := filepath.Rel(dir, p)
+			if err != nil {
+				return p
+			}
+			return filepath.Join(orig, rel)
+		}
+	}
 }
 
 func (s *State) findRefsByPath(absPath string) []fileRef {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -957,11 +957,22 @@ func (s *State) watchLoop() {
 				return
 			}
 			eventPath := s.translateEventPath(event.Name)
+			// State entries may be stored under either the original or the
+			// canonical form (e.g. when the user mixes /var/... and
+			// /private/var/... explicitly), so look up refs for both paths
+			// when they differ. Each FileEntry has a single Path string, so
+			// the union cannot double-fire on the same entry.
 			refs := s.findRefsByPath(eventPath)
+			if eventPath != event.Name {
+				refs = append(refs, s.findRefsByPath(event.Name)...)
+			}
 			if len(refs) > 0 {
 				if event.Op.Has(fsnotify.Write) || event.Op.Has(fsnotify.Create) {
 					slog.Info("file changed", "path", eventPath)
 					s.scheduleFileChanged(eventPath)
+					if eventPath != event.Name {
+						s.scheduleFileChanged(event.Name)
+					}
 				}
 				// Editors using atomic save (write-to-temp + rename) cause
 				// the original inode to disappear, which removes the watch.
@@ -977,12 +988,19 @@ func (s *State) watchLoop() {
 						} else {
 							slog.Info("re-watching file", "path", eventPath)
 							s.scheduleFileChanged(eventPath)
+							if eventPath != event.Name {
+								s.scheduleFileChanged(event.Name)
+							}
 						}
 					})
 				}
 			}
-			if (event.Op.Has(fsnotify.Rename) || event.Op.Has(fsnotify.Remove)) && s.isWatchedDir(eventPath) {
-				s.handleDirMove(eventPath)
+			if event.Op.Has(fsnotify.Rename) || event.Op.Has(fsnotify.Remove) {
+				if s.isWatchedDir(eventPath) {
+					s.handleDirMove(eventPath)
+				} else if eventPath != event.Name && s.isWatchedDir(event.Name) {
+					s.handleDirMove(event.Name)
+				}
 			}
 			if event.Op.Has(fsnotify.Create) {
 				s.handleCreateForGlobs(eventPath)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -960,17 +960,21 @@ func (s *State) watchLoop() {
 			// State entries may be stored under either the original or the
 			// canonical form (e.g. when the user mixes /var/... and
 			// /private/var/... explicitly), so look up refs for both paths
-			// when they differ. Each FileEntry has a single Path string, so
-			// the union cannot double-fire on the same entry.
-			refs := s.findRefsByPath(eventPath)
+			// when they differ. Track each set separately so file-change
+			// scheduling only runs for the form(s) that actually matched,
+			// while delete handling still operates on the union.
+			refsTranslated := s.findRefsByPath(eventPath)
+			var refsRaw []fileRef
 			if eventPath != event.Name {
-				refs = append(refs, s.findRefsByPath(event.Name)...)
+				refsRaw = s.findRefsByPath(event.Name)
 			}
-			if len(refs) > 0 {
+			if len(refsTranslated)+len(refsRaw) > 0 {
 				if event.Op.Has(fsnotify.Write) || event.Op.Has(fsnotify.Create) {
 					slog.Info("file changed", "path", eventPath)
-					s.scheduleFileChanged(eventPath)
-					if eventPath != event.Name {
+					if len(refsTranslated) > 0 {
+						s.scheduleFileChanged(eventPath)
+					}
+					if len(refsRaw) > 0 {
 						s.scheduleFileChanged(event.Name)
 					}
 				}
@@ -982,13 +986,18 @@ func (s *State) watchLoop() {
 						if err := s.watcher.Add(eventPath, watchOps); err != nil {
 							// File is actually gone — remove from file list
 							slog.Info("file deleted, removing from list", "path", eventPath)
-							for _, ref := range refs {
+							for _, ref := range refsTranslated {
+								s.RemoveFile(ref.ID, ref.Group)
+							}
+							for _, ref := range refsRaw {
 								s.RemoveFile(ref.ID, ref.Group)
 							}
 						} else {
 							slog.Info("re-watching file", "path", eventPath)
-							s.scheduleFileChanged(eventPath)
-							if eventPath != event.Name {
+							if len(refsTranslated) > 0 {
+								s.scheduleFileChanged(eventPath)
+							}
+							if len(refsRaw) > 0 {
 								s.scheduleFileChanged(event.Name)
 							}
 						}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1761,17 +1761,14 @@ func TestPathAliasRegisterAndUnregister(t *testing.T) {
 	}
 
 	// Build a temp dir whose path differs from its EvalSymlinks form on macOS
-	// (e.g. /var/... → /private/var/...), so registerPathAlias has work to do.
+	// (e.g. /var/... → /private/var/...), so resolvePathAlias has work to do.
 	dir := t.TempDir()
-	canonical, err := filepath.EvalSymlinks(dir)
-	if err != nil {
-		t.Fatalf("EvalSymlinks: %v", err)
-	}
-	if canonical == dir {
+	canonical := resolvePathAlias(dir)
+	if canonical == "" {
 		t.Skipf("temp dir %q is already canonical; skipping", dir)
 	}
 
-	s.registerPathAlias(dir)
+	s.registerPathAlias(dir, canonical)
 	if got := s.pathAliases[canonical]; got != dir {
 		t.Errorf("pathAliases[%q] = %q, want %q", canonical, got, dir)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1756,6 +1756,40 @@ func TestTranslateEventPath(t *testing.T) {
 	}
 }
 
+func TestFindRefsByPath_CoversBothPathFormsViaUnion(t *testing.T) {
+	originalDir := filepath.FromSlash("/var/foo/docs")
+	canonicalDir := filepath.FromSlash("/private/var/foo/docs")
+	originalFile := filepath.Join(originalDir, "x.md")
+	canonicalFile := filepath.Join(canonicalDir, "x.md")
+
+	s := &State{
+		groups: map[string]*Group{
+			DefaultGroup: {Name: DefaultGroup, Files: []*FileEntry{
+				{ID: "orig", Path: originalFile},
+				{ID: "canon", Path: canonicalFile},
+			}},
+		},
+		pathAliases: map[string]string{canonicalDir: originalDir},
+	}
+
+	// Simulate the event delivered for canonicalFile and the watchLoop's
+	// union of findRefsByPath(translated) ∪ findRefsByPath(raw).
+	eventName := canonicalFile
+	eventPath := s.translateEventPath(eventName)
+	refs := s.findRefsByPath(eventPath)
+	if eventPath != eventName {
+		refs = append(refs, s.findRefsByPath(eventName)...)
+	}
+
+	got := map[string]bool{}
+	for _, r := range refs {
+		got[r.ID] = true
+	}
+	if !got["orig"] || !got["canon"] {
+		t.Errorf("union refs = %v, want both \"orig\" and \"canon\"", got)
+	}
+}
+
 func TestPathAliasRegisterAndUnregister(t *testing.T) {
 	s := &State{
 		pathAliases:  map[string]string{},

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1754,6 +1754,43 @@ func TestTranslateEventPath(t *testing.T) {
 	}
 }
 
+func TestPathAliasRegisterAndUnregister(t *testing.T) {
+	s := &State{
+		pathAliases:  map[string]string{},
+		aliasReverse: map[string]string{},
+	}
+
+	// Build a temp dir whose path differs from its EvalSymlinks form on macOS
+	// (e.g. /var/... → /private/var/...), so registerPathAlias has work to do.
+	dir := t.TempDir()
+	canonical, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if canonical == dir {
+		t.Skipf("temp dir %q is already canonical; skipping", dir)
+	}
+
+	s.registerPathAlias(dir)
+	if got := s.pathAliases[canonical]; got != dir {
+		t.Errorf("pathAliases[%q] = %q, want %q", canonical, got, dir)
+	}
+	if got := s.aliasReverse[dir]; got != canonical {
+		t.Errorf("aliasReverse[%q] = %q, want %q", dir, got, canonical)
+	}
+
+	s.unregisterPathAlias(dir)
+	if _, ok := s.pathAliases[canonical]; ok {
+		t.Errorf("pathAliases[%q] still present after unregister", canonical)
+	}
+	if _, ok := s.aliasReverse[dir]; ok {
+		t.Errorf("aliasReverse[%q] still present after unregister", dir)
+	}
+
+	// unregister of an unknown path is a no-op.
+	s.unregisterPathAlias("/nonexistent")
+}
+
 func TestExtractTitle(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1731,8 +1731,10 @@ func TestDirMove(t *testing.T) {
 }
 
 func TestTranslateEventPath(t *testing.T) {
+	canonicalDir := filepath.FromSlash("/private/var/foo/docs")
+	originalDir := filepath.FromSlash("/var/foo/docs")
 	s := &State{pathAliases: map[string]string{
-		"/private/var/foo/docs": "/var/foo/docs",
+		canonicalDir: originalDir,
 	}}
 
 	tests := []struct {
@@ -1740,10 +1742,10 @@ func TestTranslateEventPath(t *testing.T) {
 		in   string
 		want string
 	}{
-		{"exact match", "/private/var/foo/docs", "/var/foo/docs"},
-		{"prefix match for file under aliased dir", "/private/var/foo/docs/new.md", "/var/foo/docs/new.md"},
-		{"prefix match for nested file", "/private/var/foo/docs/sub/note.md", "/var/foo/docs/sub/note.md"},
-		{"no alias passes through", "/other/path/file.md", "/other/path/file.md"},
+		{"exact match", canonicalDir, originalDir},
+		{"prefix match for file under aliased dir", filepath.Join(canonicalDir, "new.md"), filepath.Join(originalDir, "new.md")},
+		{"prefix match for nested file", filepath.Join(canonicalDir, "sub", "note.md"), filepath.Join(originalDir, "sub", "note.md")},
+		{"no alias passes through", filepath.FromSlash("/other/path/file.md"), filepath.FromSlash("/other/path/file.md")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1730,6 +1730,30 @@ func TestDirMove(t *testing.T) {
 	}
 }
 
+func TestTranslateEventPath(t *testing.T) {
+	s := &State{pathAliases: map[string]string{
+		"/private/var/foo/docs": "/var/foo/docs",
+	}}
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"exact match", "/private/var/foo/docs", "/var/foo/docs"},
+		{"prefix match for file under aliased dir", "/private/var/foo/docs/new.md", "/var/foo/docs/new.md"},
+		{"prefix match for nested file", "/private/var/foo/docs/sub/note.md", "/var/foo/docs/sub/note.md"},
+		{"no alias passes through", "/other/path/file.md", "/other/path/file.md"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s.translateEventPath(tt.in); got != tt.want {
+				t.Errorf("translateEventPath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExtractTitle(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

- Switch the file watcher dependency from `github.com/fsnotify/fsnotify` v1.10.0 to `github.com/gofsnotify/fsnotify` v0.0.4.
- Adapt to the new API: `Watcher.Add` now takes an `Op` mask, and `Has` is defined on `Op` rather than `Event` (so callers use `event.Op.Has(...)`).
- Subscribe only to `Create|Write|Remove|Rename` (the ops the watch loop handles); `Chmod` is intentionally excluded.
- Translate event paths back to stored keys: the new watcher canonicalizes paths (resolving symlinks), so events arrive in a form like `/private/var/...` while our state keeps the user-facing form (`/var/...`). A small `pathAliases` map populated at each `Add` call lets the watch loop look up the original stored path before downstream comparisons. This keeps `FileEntry.Path` (and hence the on-disk backup format) unchanged.