### PR TITLE
fix: keep watched files on coalesced rename flags from FSEvents

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -979,12 +979,16 @@ func (s *State) watchLoop() {
 					}
 				}
 				// Editors using atomic save (write-to-temp + rename) cause
-				// the original inode to disappear, which removes the watch.
-				// Re-add the watch so subsequent saves are still detected.
+				// the original inode to disappear, which removes the watch on
+				// some backends. Stat the path to decide whether the file is
+				// actually gone, then re-add the watch if it still exists.
+				// FSEvents on macOS coalesces historical flags, so a plain
+				// Write after a previous atomic save arrives as Write|Rename;
+				// trusting Add's error to mean "file gone" wrongly drops the
+				// entry (ErrAlreadyAdded for a still-live watch).
 				if event.Op.Has(fsnotify.Remove) || event.Op.Has(fsnotify.Rename) {
 					time.AfterFunc(100*time.Millisecond, func() {
-						if err := s.watcher.Add(eventPath, watchOps); err != nil {
-							// File is actually gone — remove from file list
+						if _, statErr := os.Stat(eventPath); errors.Is(statErr, os.ErrNotExist) {
 							slog.Info("file deleted, removing from list", "path", eventPath)
 							for _, ref := range refsTranslated {
 								s.RemoveFile(ref.ID, ref.Group)
@@ -992,14 +996,18 @@ func (s *State) watchLoop() {
 							for _, ref := range refsRaw {
 								s.RemoveFile(ref.ID, ref.Group)
 							}
-						} else {
-							slog.Info("re-watching file", "path", eventPath)
-							if len(refsTranslated) > 0 {
-								s.scheduleFileChanged(eventPath)
-							}
-							if len(refsRaw) > 0 {
-								s.scheduleFileChanged(event.Name)
-							}
+							return
+						}
+						if err := s.watcher.Add(eventPath, watchOps); err != nil && !errors.Is(err, fsnotify.ErrAlreadyAdded) {
+							slog.Warn("failed to re-watch file", "path", eventPath, "error", err)
+							return
+						}
+						slog.Info("re-watching file", "path", eventPath)
+						if len(refsTranslated) > 0 {
+							s.scheduleFileChanged(eventPath)
+						}
+						if len(refsRaw) > 0 {
+							s.scheduleFileChanged(event.Name)
 						}
 					})
 				}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1730,6 +1730,52 @@ func TestDirMove(t *testing.T) {
 	}
 }
 
+func TestWatchedFile_RetainedAfterAtomicSaveRewrite(t *testing.T) {
+	// Regression: macOS FSEvents coalesces historical flags, so a plain
+	// Write after a previous atomic save (write tmp + rename) arrives as
+	// Write|Rename. The watchLoop must not drop the file from the list in
+	// that case; only an actually-missing file should be removed.
+	ctx, cancel := donegroup.WithCancel(context.Background())
+	defer cancel()
+
+	s := NewState(ctx)
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "foo.md")
+	if err := os.WriteFile(target, []byte("# init"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pattern := filepath.Join(dir, "*.md")
+	entries, err := s.AddPattern(pattern, DefaultGroup)
+	if err != nil {
+		t.Fatalf("AddPattern returned error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	id := entries[0].ID
+
+	tmp := target + ".tmp"
+	if err := os.WriteFile(tmp, []byte("# atomic"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(target, []byte("# rewrite"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait past the watchLoop's 100ms re-watch delay plus the debounce.
+	time.Sleep(500 * time.Millisecond)
+
+	if s.FindFile(id, DefaultGroup) == nil {
+		t.Fatalf("file %q was wrongly removed from the list after rewrite", target)
+	}
+}
+
 func TestTranslateEventPath(t *testing.T) {
 	canonicalDir := filepath.FromSlash("/private/var/foo/docs")
 	originalDir := filepath.FromSlash("/var/foo/docs")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1739,6 +1739,7 @@ func TestWatchedFile_RetainedAfterAtomicSaveRewrite(t *testing.T) {
 	defer cancel()
 
 	s := NewState(ctx)
+	t.Cleanup(s.CloseAllSubscribers)
 
 	dir := t.TempDir()
 	target := filepath.Join(dir, "foo.md")
@@ -1768,11 +1769,20 @@ func TestWatchedFile_RetainedAfterAtomicSaveRewrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait past the watchLoop's 100ms re-watch delay plus the debounce.
-	time.Sleep(500 * time.Millisecond)
-
-	if s.FindFile(id, DefaultGroup) == nil {
-		t.Fatalf("file %q was wrongly removed from the list after rewrite", target)
+	// Poll FindFile until the watchLoop has had time to process the
+	// Write|Rename event (re-watch delay 100ms + debounce). Fail fast if
+	// the file is dropped at any point during the window.
+	deadline := time.After(2 * time.Second)
+	for {
+		if s.FindFile(id, DefaultGroup) == nil {
+			t.Fatalf("file %q was wrongly removed from the list after rewrite", target)
+		}
+		select {
+		case <-deadline:
+			return
+		default:
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix a bug where a `.md` file in a watched directory was wrongly removed from the list when it was updated, after the file had been touched by an atomic save (write tmp + rename) earlier.
- macOS FSEvents (via `gofsnotify`) coalesces historical flags, so a plain write after a previous atomic save arrives as `Write|Rename`. The watchLoop relied on `s.watcher.Add` returning an error to mean "file gone", but `gofsnotify` returns `ErrAlreadyAdded` for a still-live watch, which dropped the entry.
- Now `os.Stat` decides whether the file is actually missing; the re-add is best-effort and `ErrAlreadyAdded` is treated as a no-op.
- Added a regression test that registers a glob pattern, performs an atomic save followed by a plain rewrite, and asserts the file remains in the list.