### PR TITLE
docs(security): clarify threat model for local HTTP server

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,4 +21,10 @@ Reports related to the following are in scope:
 - Authentication or authorization bypass on the local server
 - Remote code execution
 
+### Threat model
+
+`mo` is a local development tool. By default it binds to `localhost` and serves files the user has explicitly opened to that same user's browser. The user already has OS-level read access to anything `mo` can read, so file access by the user (or by the user's browser) over the loopback interface is not considered "unauthorized" and does not by itself constitute path traversal in the security sense. Reports of this shape are out of scope.
+
+In-scope path traversal requires a path to access from a party that does not already have equivalent filesystem access (for example, via cross-origin requests that bypass browser protections, or via a vector that does not rely on `--dangerously-allow-remote-access`).
+
 The `--dangerously-allow-remote-access` flag intentionally disables access restrictions. Vulnerabilities that require this flag to be enabled are generally out of scope, as the flag name itself signals the associated risk.


### PR DESCRIPTION
## Summary

- Add a "Threat model" subsection to `SECURITY.md` describing that `mo` is a local HTTP server bound to `localhost` by default, serving files the user explicitly opened to that same user's browser
- Make explicit that file access by the user (or by the user's browser) over the loopback interface is not "unauthorized" and does not by itself constitute path traversal in the security sense
- Describe what would actually qualify as in-scope path traversal (a vector reaching `mo` from a party without equivalent filesystem access, not relying on `--dangerously-allow-remote-access`)
- The existing `--dangerously-allow-remote-access` paragraph is preserved as-is

### Motivation

Without the threat model written down, the "Unauthorized file access or path traversal" line in Scope was easy to read as covering any path boundary anywhere in the server. #222 surfaced this: the raw asset endpoint had a string-prefix containment check, but other endpoints (e.g. `handleOpenFile`) intentionally do not enforce a boundary, and tightening only the raw side would not have produced a real security boundary under either the default loopback bind or the `--dangerously-allow-remote-access` mode. Writing the threat model down makes the existing design self-consistent for future reports and PRs.