### PR TITLE
feat(frontend): open relative links in a new tab on modifier-click

### DIFF
--- a/internal/frontend/src/App.tsx
+++ b/internal/frontend/src/App.tsx
@@ -19,11 +19,18 @@ import { useFileDrop } from "./hooks/useFileDrop";
 import { useActiveHeading } from "./hooks/useActiveHeading";
 import { useScrollRestoration, SCROLL_SESSION_KEY } from "./hooks/useScrollRestoration";
 import type { FileEntry, Group, SearchResult } from "./hooks/useApi";
-import { fetchGroups, fetchSearchResults, removeFile, reorderFiles } from "./hooks/useApi";
+import {
+  fetchGroups,
+  fetchSearchResults,
+  openRelativeFile,
+  removeFile,
+  reorderFiles,
+} from "./hooks/useApi";
 import {
   allFileIds,
   parseGroupFromPath,
   parseFileIdFromSearch,
+  parseRelativeOpenFromSearch,
   groupToPath,
   buildFileUrl,
 } from "./utils/groups";
@@ -219,10 +226,36 @@ export function App() {
       .catch(() => {});
   }, []);
 
+  // A relative Markdown link opened in a new tab lands here with from/open params
+  // because the target file has no ID until the server resolves it. Resolve it once
+  // on load, then rewrite the URL to the canonical ?file= form.
+  const relativeOpen = useRef(parseRelativeOpenFromSearch(window.location.search));
+  const relativeOpenStarted = useRef(false);
+  useEffect(() => {
+    if (relativeOpenStarted.current) return;
+    const rel = relativeOpen.current;
+    if (!rel) return;
+    relativeOpenStarted.current = true;
+    const group = parseGroupFromPath(window.location.pathname);
+    openRelativeFile(group, rel.from, rel.open)
+      .then((entry) => {
+        relativeOpen.current = null;
+        setInitialFileId(entry.id);
+        window.history.replaceState(null, "", buildFileUrl(group, entry.id));
+        loadGroups();
+      })
+      .catch(() => {
+        relativeOpen.current = null;
+        window.history.replaceState(null, "", groupToPath(group));
+      });
+  }, [loadGroups]);
+
   // User-initiated navigation (file/group selection) calls pushState directly at
   // the call site. This effect only reconciles the URL with state for automatic
   // changes (initial mount, SSE updates, render-time fallbacks) via replaceState.
   useEffect(() => {
+    // A relative-open resolve is in flight; it owns the URL until it settles.
+    if (relativeOpen.current != null) return;
     // initialFileId hasn't been consumed yet — keep the URL as the user landed.
     if (initialFileId != null) return;
     const expectedUrl = activeFileId

--- a/internal/frontend/src/components/MarkdownViewer.test.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MarkdownViewer } from "./MarkdownViewer";
-import { openRelativeFile } from "../hooks/useApi";
+import { fetchFileContent, openRelativeFile } from "../hooks/useApi";
 
 vi.mock("mermaid", () => ({
   default: {
@@ -14,8 +14,6 @@ vi.mock("../hooks/useApi", () => ({
   fetchFileContent: vi.fn().mockResolvedValue({ content: "# Hello", baseDir: "/repo" }),
   openRelativeFile: vi.fn(),
 }));
-
-import { fetchFileContent } from "../hooks/useApi";
 
 // jsdom has no layout, so stub getBoundingClientRect: the scroll container and
 // the sticky bar sit at the top, and the heading goes wherever a test wants it.

--- a/internal/frontend/src/components/MarkdownViewer.test.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MarkdownViewer } from "./MarkdownViewer";
+import { openRelativeFile } from "../hooks/useApi";
 
 vi.mock("mermaid", () => ({
   default: {
@@ -13,6 +14,8 @@ vi.mock("../hooks/useApi", () => ({
   fetchFileContent: vi.fn().mockResolvedValue({ content: "# Hello", baseDir: "/repo" }),
   openRelativeFile: vi.fn(),
 }));
+
+import { fetchFileContent } from "../hooks/useApi";
 
 // jsdom has no layout, so stub getBoundingClientRect: the scroll container and
 // the sticky bar sit at the top, and the heading goes wherever a test wants it.
@@ -113,5 +116,49 @@ describe("MarkdownViewer file label", () => {
 
     const label = await screen.findByTitle("/home/me/code/mo/docs/README.md");
     expect(label).toHaveClass("text-right");
+  });
+});
+
+describe("MarkdownViewer relative links", () => {
+  beforeEach(() => {
+    vi.mocked(fetchFileContent).mockResolvedValue({
+      content: "[Next page](next.md)",
+      baseDir: "/repo",
+    });
+    vi.mocked(openRelativeFile).mockResolvedValue({
+      id: "bbb22222",
+      name: "next.md",
+      path: "/repo/next.md",
+    });
+  });
+
+  it("points the href at a self-resolving relative-open URL", async () => {
+    renderViewer();
+    const link = await screen.findByRole("link", { name: "Next page" });
+    expect(link).toHaveAttribute("href", "/?from=aaa11111&open=next.md");
+  });
+
+  it("opens in place on a plain click", async () => {
+    const onFileOpened = vi.fn();
+    renderViewer({ onFileOpened });
+    const link = await screen.findByRole("link", { name: "Next page" });
+
+    const notPrevented = fireEvent.click(link);
+
+    expect(notPrevented).toBe(false); // preventDefault was called
+    await waitFor(() => expect(onFileOpened).toHaveBeenCalledWith("bbb22222"));
+    expect(openRelativeFile).toHaveBeenCalledWith("default", "aaa11111", "next.md");
+  });
+
+  it("lets the browser handle a Cmd/Ctrl click natively", async () => {
+    const onFileOpened = vi.fn();
+    renderViewer({ onFileOpened });
+    const link = await screen.findByRole("link", { name: "Next page" });
+
+    const notPrevented = fireEvent.click(link, { metaKey: true });
+
+    expect(notPrevented).toBe(true); // default preserved → new browser tab
+    expect(openRelativeFile).not.toHaveBeenCalled();
+    expect(onFileOpened).not.toHaveBeenCalled();
   });
 });

--- a/internal/frontend/src/components/MarkdownViewer.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.tsx
@@ -677,7 +677,8 @@ export function MarkdownViewer({
                 href={buildRelativeOpenUrl(activeGroup, fileId, resolved.hrefPath)}
                 onClick={(e) => {
                   // Modifier / middle clicks fall through so the browser opens the
-                  // resolved href in a new tab; only a plain click navigates in place.
+                  // self-resolving href in a new tab (App resolves it on load); only a
+                  // plain click navigates in place.
                   if (!isPlainLeftClick(e)) return;
                   handleLinkClick(e, resolved.hrefPath);
                 }}

--- a/internal/frontend/src/components/MarkdownViewer.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.tsx
@@ -18,6 +18,7 @@ import { TocToggle } from "./TocToggle";
 import { CopyButton } from "./CopyButton";
 import { CloseFileButton } from "./CloseFileButton";
 import { resolveLink, resolveImageSrc, extractLanguage } from "../utils/resolve";
+import { buildRelativeOpenUrl } from "../utils/groups";
 import { parseFrontmatter } from "../utils/frontmatter";
 import { stripMdxSyntax } from "../utils/mdx";
 import { isMarkdownFile, detectLanguage } from "../utils/filetype";
@@ -672,7 +673,16 @@ export function MarkdownViewer({
             );
           case "markdown":
             return (
-              <a href={href} onClick={(e) => handleLinkClick(e, resolved.hrefPath)} {...props}>
+              <a
+                href={buildRelativeOpenUrl(activeGroup, fileId, resolved.hrefPath)}
+                onClick={(e) => {
+                  // Modifier / middle clicks fall through so the browser opens the
+                  // resolved href in a new tab; only a plain click navigates in place.
+                  if (!isPlainLeftClick(e)) return;
+                  handleLinkClick(e, resolved.hrefPath);
+                }}
+                {...props}
+              >
                 {children}
               </a>
             );
@@ -691,7 +701,7 @@ export function MarkdownViewer({
         }
       },
     }),
-    [fileId, handleLinkClick, onZoom],
+    [activeGroup, fileId, handleLinkClick, onZoom],
   );
 
   const isMarkdown = isMarkdownFile(fileName);

--- a/internal/frontend/src/utils/groups.test.ts
+++ b/internal/frontend/src/utils/groups.test.ts
@@ -5,6 +5,8 @@ import {
   groupToPath,
   buildFileUrl,
   parseFileIdFromSearch,
+  buildRelativeOpenUrl,
+  parseRelativeOpenFromSearch,
 } from "./groups";
 import type { Group } from "../hooks/useApi";
 
@@ -116,5 +118,45 @@ describe("parseFileIdFromSearch", () => {
 
   it("returns null for empty value", () => {
     expect(parseFileIdFromSearch("?file=")).toBeNull();
+  });
+});
+
+describe("buildRelativeOpenUrl", () => {
+  it("encodes source id and relative path for the default group", () => {
+    expect(buildRelativeOpenUrl("default", "abc12345", "next.md")).toBe(
+      "/?from=abc12345&open=next.md",
+    );
+  });
+
+  it("encodes a nested path for a named group", () => {
+    expect(buildRelativeOpenUrl("design", "abc12345", "docs/guide.mdx")).toBe(
+      "/design?from=abc12345&open=docs%2Fguide.mdx",
+    );
+  });
+
+  it("round-trips a path with spaces back to the original", () => {
+    const url = buildRelativeOpenUrl("default", "abc12345", "a b.md");
+    expect(parseRelativeOpenFromSearch(url.slice(url.indexOf("?")))?.open).toBe("a b.md");
+  });
+});
+
+describe("parseRelativeOpenFromSearch", () => {
+  it("returns null for empty search", () => {
+    expect(parseRelativeOpenFromSearch("")).toBeNull();
+  });
+
+  it("parses from and open params", () => {
+    expect(parseRelativeOpenFromSearch("?from=abc12345&open=docs%2Fguide.mdx")).toEqual({
+      from: "abc12345",
+      open: "docs/guide.mdx",
+    });
+  });
+
+  it("returns null when from is missing", () => {
+    expect(parseRelativeOpenFromSearch("?open=next.md")).toBeNull();
+  });
+
+  it("returns null when open is missing", () => {
+    expect(parseRelativeOpenFromSearch("?from=abc12345")).toBeNull();
   });
 });

--- a/internal/frontend/src/utils/groups.ts
+++ b/internal/frontend/src/utils/groups.ts
@@ -29,3 +29,30 @@ export function parseFileIdFromSearch(search: string): string | null {
   if (raw == null || raw === "") return null;
   return raw;
 }
+
+export interface RelativeOpenRequest {
+  // ID of the source file the relative link was rendered in.
+  from: string;
+  // Relative path to resolve against the source file, as written in the link.
+  open: string;
+}
+
+// A relative Markdown link has no file ID until the server resolves it, so a new
+// browser tab cannot be pointed straight at buildFileUrl. This URL carries the
+// source file and the relative path instead, and the SPA resolves it on load.
+export function buildRelativeOpenUrl(
+  groupName: string,
+  sourceFileId: string,
+  relativePath: string,
+): string {
+  const params = new URLSearchParams({ from: sourceFileId, open: relativePath });
+  return `${groupToPath(groupName)}?${params.toString()}`;
+}
+
+export function parseRelativeOpenFromSearch(search: string): RelativeOpenRequest | null {
+  const params = new URLSearchParams(search);
+  const from = params.get("from");
+  const open = params.get("open");
+  if (!from || !open) return null;
+  return { from, open };
+}


### PR DESCRIPTION
## Summary

Relative Markdown links in the document body always called `preventDefault`, so Cmd/Ctrl+Click and middle-click could not open the linked file in a new browser tab — the one navigation case still missing the browser-native behavior that sidebar, tree, and ToC links gained in #194. When reading docs split across several files, opening a linked page in a new tab while keeping the current one is a common need (#216).

A relative link has no file ID until the server resolves it against the source file, so it cannot point straight at the canonical `?file=<id>` URL. Instead each relative link now carries a self-resolving href, `?from=<sourceId>&open=<relpath>`. A new tab opened on that href resolves it on load through the existing open API, registers the target file, then rewrites the URL to the canonical `?file=<id>` form. Only a plain left-click is still intercepted for in-place navigation, mirroring the hash-link passthrough pattern already in `MarkdownViewer`, so Cmd/Ctrl/middle clicks fall through to the browser unchanged. Existing hash-link behavior is untouched.

Verified with the frontend unit suite (`groups` URL helpers, plus `MarkdownViewer` href/plain-click/modifier-click behavior) and end-to-end against the real embedded binary: a modifier-click opens the relative target in a new tab and registers it, while a plain click still navigates in place.

Closes #216