### PR TITLE
fix(frontend): increase z-index of `GroupDropdown` not to be concealed by active file label

### DIFF
--- a/internal/frontend/src/components/GroupDropdown.tsx
+++ b/internal/frontend/src/components/GroupDropdown.tsx
@@ -78,7 +78,7 @@ export function GroupDropdown({ groups, activeGroup, onGroupChange }: GroupDropd
         </svg>
       </button>
       {open && (
-        <div className="absolute left-0 top-full mt-1 min-w-40 bg-gh-bg-sidebar border border-gh-border rounded-md shadow-lg z-10 flex flex-col">
+        <div className="absolute left-0 top-full mt-1 min-w-40 bg-gh-bg-sidebar border border-gh-border rounded-md shadow-lg z-30 flex flex-col">
           {canScrollUp && (
             <div className="flex justify-center py-0.5 text-gh-text-secondary border-b border-gh-border">
               <svg className="size-3" fill="currentColor" viewBox="0 0 12 12">


### PR DESCRIPTION
resovles #238 

## Before this PR ( 319814e04d86 )
https://github.com/user-attachments/assets/eb2aef4e-96b2-470f-aa05-ca4e520f2038

## This PR
https://github.com/user-attachments/assets/e10d00da-1616-4953-8993-4f67b56f5c4d