### PR TITLE
feat: hint how to unwatch when an empty group is kept alive by patterns

### DIFF
--- a/.gostyle.yml
+++ b/.gostyle.yml
@@ -2,6 +2,12 @@ analyzers:
   disable:
     - mixedcaps
     - funcfmt
+    # nilslices conflates nil and empty slices, but the HTTP API
+    # deliberately distinguishes them in JSON output ("files": null
+    # vs "files": []), and that distinction is enforced at the
+    # encoding boundary in handleGroups. The internal-API rationale
+    # the analyzer encodes does not apply at that boundary.
+    - nilslices
 analyzers-settings:
   errorstrings:
     exclude-test: true

--- a/.gostyle.yml
+++ b/.gostyle.yml
@@ -2,11 +2,14 @@ analyzers:
   disable:
     - mixedcaps
     - funcfmt
-    # nilslices conflates nil and empty slices, but the HTTP API
-    # deliberately distinguishes them in JSON output ("files": null
-    # vs "files": []), and that distinction is enforced at the
-    # encoding boundary in handleGroups. The internal-API rationale
-    # the analyzer encodes does not apply at that boundary.
+    # handleGroups explicitly checks `g.Files == nil` so it can
+    # normalize a nil slice to an empty literal and avoid emitting
+    # `"files": null` over the wire. nilslices flags exactly that
+    # nil-vs-empty distinction, which is what makes the
+    # normalization possible — disable the analyzer rather than
+    # paper over the encoding fix with a `len() == 0` branch that
+    # would also rewrite already-empty non-nil slices on every
+    # request.
     - nilslices
 analyzers-settings:
   errorstrings:

--- a/internal/frontend/src/App.tsx
+++ b/internal/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { ZoomModal } from "./components/ZoomModal";
 import type { ZoomContent } from "./components/ZoomModal";
 import { TocPanel } from "./components/TocPanel";
 import type { TocHeading } from "./components/TocPanel";
+import { EmptyGroupMessage } from "./components/EmptyGroupMessage";
 import { useSSE } from "./hooks/useSSE";
 import { useFileDrop } from "./hooks/useFileDrop";
 import { useActiveHeading } from "./hooks/useActiveHeading";
@@ -306,9 +307,13 @@ export function App() {
     };
   }, [searchQuery, activeGroup]);
 
+  const activeGroupData = useMemo(
+    () => groups.find((g) => g.name === activeGroup),
+    [groups, activeGroup],
+  );
   const activeFile = useMemo(
-    () => groups.find((g) => g.name === activeGroup)?.files.find((f) => f.id === activeFileId),
-    [groups, activeGroup, activeFileId],
+    () => activeGroupData?.files.find((f) => f.id === activeFileId),
+    [activeGroupData, activeFileId],
   );
   const activeFileName = activeFile?.name ?? "";
   const tocOpen = isTocOpenForFile(tocOpenMap, activeFileId, activeFileName);
@@ -561,9 +566,7 @@ export function App() {
                 searchQuery={searchQuery}
               />
             ) : (
-              <div className="flex items-center justify-center h-50 text-gh-text-secondary text-sm">
-                No file selected
-              </div>
+              <EmptyGroupMessage group={activeGroupData} />
             )}
           </div>
         </main>

--- a/internal/frontend/src/components/EmptyGroupMessage.test.tsx
+++ b/internal/frontend/src/components/EmptyGroupMessage.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { EmptyGroupMessage } from "./EmptyGroupMessage";
+import type { Group } from "../hooks/useApi";
+
+const writeText = vi.fn();
+
+beforeEach(() => {
+  writeText.mockReset();
+  writeText.mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    writable: true,
+    configurable: true,
+  });
+
+  // Pretend the SPA is served on the default mo port unless a test overrides it.
+  setLocationPort("6275");
+});
+
+afterEach(() => {
+  setLocationPort("6275");
+});
+
+function setLocationPort(port: string) {
+  Object.defineProperty(window, "location", {
+    value: { ...window.location, port },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function makeGroup(overrides: Partial<Group> = {}): Group {
+  return { name: "default", files: [], ...overrides };
+}
+
+// Find the rendered command for a pattern by locating the <code> whose text
+// contains the given substring (a unique fragment of the pattern that
+// survives shell-quoting). Returns the command without the leading "$ ".
+function commandFor(uniqueSubstring: string): string {
+  const codes = Array.from(document.querySelectorAll("code"));
+  const target = codes.find((c) => c.textContent?.includes(uniqueSubstring));
+  if (!target) {
+    const rendered = codes.map((c) => c.textContent).join("\n");
+    throw new Error(`<code> containing "${uniqueSubstring}" not found. Rendered:\n${rendered}`);
+  }
+  return target.textContent!.replace(/^\s*\$\s+/, "").trim();
+}
+
+describe("EmptyGroupMessage", () => {
+  it('falls back to "No file selected" when the group has no patterns', () => {
+    render(<EmptyGroupMessage group={makeGroup()} />);
+    expect(screen.getByText("No file selected")).toBeInTheDocument();
+  });
+
+  it('falls back to "No file selected" when the group is undefined', () => {
+    render(<EmptyGroupMessage group={undefined} />);
+    expect(screen.getByText("No file selected")).toBeInTheDocument();
+  });
+
+  it('falls back to "No file selected" when the group still has files', () => {
+    const group = makeGroup({
+      patterns: ["/abs/foo/*.md"],
+      files: [{ name: "a.md", id: "abc12345", path: "/abs/foo/a.md" }],
+    });
+    render(<EmptyGroupMessage group={group} />);
+    expect(screen.getByText("No file selected")).toBeInTheDocument();
+    expect(screen.queryByText(/No file in this group/)).not.toBeInTheDocument();
+  });
+
+  it("renders an unwatch command per pattern in the default group on the default port", () => {
+    const group = makeGroup({ patterns: ["/abs/foo/*.md", "/abs/bar/**/*.md"] });
+    render(<EmptyGroupMessage group={group} />);
+
+    expect(screen.getByText("No file in this group.")).toBeInTheDocument();
+    expect(commandFor("/abs/foo/")).toBe("mo --unwatch '/abs/foo/*.md'");
+    expect(commandFor("/abs/bar/")).toBe("mo --unwatch '/abs/bar/**/*.md'");
+  });
+
+  it("appends -t <group> for a non-default group name", () => {
+    const group = makeGroup({ name: "design", patterns: ["/abs/d/*.md"] });
+    render(<EmptyGroupMessage group={group} />);
+    expect(commandFor("/abs/d/")).toBe("mo --unwatch '/abs/d/*.md' -t design");
+  });
+
+  it("appends -p <port> when the server is on a non-default port", () => {
+    setLocationPort("16275");
+    const group = makeGroup({ patterns: ["/abs/foo/*.md"] });
+    render(<EmptyGroupMessage group={group} />);
+    expect(commandFor("/abs/foo/")).toBe("mo --unwatch '/abs/foo/*.md' -p 16275");
+  });
+
+  it("combines -t and -p when both apply", () => {
+    setLocationPort("16275");
+    const group = makeGroup({ name: "design", patterns: ["/abs/d/*.md"] });
+    render(<EmptyGroupMessage group={group} />);
+    expect(commandFor("/abs/d/")).toBe("mo --unwatch '/abs/d/*.md' -t design -p 16275");
+  });
+
+  it("omits both flags for the default group on the default port", () => {
+    const group = makeGroup({ patterns: ["/abs/foo/*.md"] });
+    render(<EmptyGroupMessage group={group} />);
+    expect(commandFor("/abs/foo/")).toBe("mo --unwatch '/abs/foo/*.md'");
+  });
+
+  it("leaves a plain pattern unquoted when no shell metacharacters are present", () => {
+    const group = makeGroup({ patterns: ["/abs/foo.md"] });
+    render(<EmptyGroupMessage group={group} />);
+    expect(commandFor("/abs/foo.md")).toBe("mo --unwatch /abs/foo.md");
+  });
+
+  it("quotes patterns containing spaces", () => {
+    const pattern = "/abs/dir with space/*.md";
+    const group = makeGroup({ patterns: [pattern] });
+    render(<EmptyGroupMessage group={group} />);
+    expect(commandFor("dir with space")).toBe(`mo --unwatch '${pattern}'`);
+  });
+
+  it("escapes embedded single quotes using the POSIX '\\'' pattern", () => {
+    const pattern = "/abs/with'quote/*.md";
+    const group = makeGroup({ patterns: [pattern] });
+    render(<EmptyGroupMessage group={group} />);
+    expect(commandFor("with")).toBe("mo --unwatch '/abs/with'\\''quote/*.md'");
+  });
+
+  it("copies the rendered command to the clipboard when the copy button is clicked", async () => {
+    const group = makeGroup({ patterns: ["/abs/foo/*.md"] });
+    render(<EmptyGroupMessage group={group} />);
+
+    fireEvent.click(screen.getByTitle("Copy command"));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledTimes(1);
+    });
+    expect(writeText).toHaveBeenCalledWith("mo --unwatch '/abs/foo/*.md'");
+    expect(await screen.findByRole("button", { name: "Command copied" })).toBeInTheDocument();
+  });
+});

--- a/internal/frontend/src/components/EmptyGroupMessage.test.tsx
+++ b/internal/frontend/src/components/EmptyGroupMessage.test.tsx
@@ -5,6 +5,11 @@ import type { Group } from "../hooks/useApi";
 
 const writeText = vi.fn();
 
+// Capture the real `window.location` descriptor once so each test can
+// override only the port and the original Location object is restored
+// after the test runs (preventing leakage into other test files).
+const originalLocationDescriptor = Object.getOwnPropertyDescriptor(window, "location");
+
 beforeEach(() => {
   writeText.mockReset();
   writeText.mockResolvedValue(undefined);
@@ -19,7 +24,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  setLocationPort("6275");
+  if (originalLocationDescriptor) {
+    Object.defineProperty(window, "location", originalLocationDescriptor);
+  }
 });
 
 function setLocationPort(port: string) {

--- a/internal/frontend/src/components/EmptyGroupMessage.tsx
+++ b/internal/frontend/src/components/EmptyGroupMessage.tsx
@@ -84,9 +84,10 @@ function CommandRow({ command }: CommandRowProps) {
 
 export function EmptyGroupMessage({ group }: EmptyGroupMessageProps) {
   const patterns = group?.patterns ?? [];
+  const fileCount = group?.files.length ?? 0;
   const groupName = group?.name ?? "";
 
-  if (patterns.length === 0) {
+  if (patterns.length === 0 || fileCount > 0) {
     return (
       <div className="flex items-center justify-center h-50 text-gh-text-secondary text-sm">
         No file selected

--- a/internal/frontend/src/components/EmptyGroupMessage.tsx
+++ b/internal/frontend/src/components/EmptyGroupMessage.tsx
@@ -10,9 +10,12 @@ function shellQuote(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
-function buildUnwatchCommand(pattern: string, groupName: string): string {
-  const flag = groupName && groupName !== "default" ? ` -t ${shellQuote(groupName)}` : "";
-  return `mo --unwatch ${shellQuote(pattern)}${flag}`;
+const DEFAULT_PORT = "6275";
+
+function buildUnwatchCommand(pattern: string, groupName: string, port: string): string {
+  const groupFlag = groupName && groupName !== "default" ? ` -t ${shellQuote(groupName)}` : "";
+  const portFlag = port && port !== DEFAULT_PORT ? ` -p ${port}` : "";
+  return `mo --unwatch ${shellQuote(pattern)}${groupFlag}${portFlag}`;
 }
 
 interface CommandRowProps {
@@ -92,6 +95,7 @@ export function EmptyGroupMessage({ group }: EmptyGroupMessageProps) {
   }
 
   const multiple = patterns.length > 1;
+  const port = typeof window !== "undefined" ? window.location.port : "";
 
   return (
     <div className="flex flex-col items-start max-w-2xl mx-auto mt-12 p-6 text-gh-text-secondary text-sm gap-4">
@@ -103,7 +107,7 @@ export function EmptyGroupMessage({ group }: EmptyGroupMessageProps) {
       </p>
       <div className="flex flex-col gap-2 w-full">
         {patterns.map((p) => (
-          <CommandRow key={p} command={buildUnwatchCommand(p, groupName)} />
+          <CommandRow key={p} command={buildUnwatchCommand(p, groupName, port)} />
         ))}
       </div>
     </div>

--- a/internal/frontend/src/components/EmptyGroupMessage.tsx
+++ b/internal/frontend/src/components/EmptyGroupMessage.tsx
@@ -47,6 +47,7 @@ function CommandRow({ command }: CommandRowProps) {
         onClick={handleCopy}
         className="shrink-0 flex items-center justify-center bg-transparent border border-gh-border rounded-md p-1.5 text-gh-text-secondary cursor-pointer transition-colors duration-150 hover:bg-gh-bg-hover"
         title="Copy command"
+        aria-label={copied ? "Command copied" : "Copy command"}
       >
         {copied ? (
           <svg

--- a/internal/frontend/src/components/EmptyGroupMessage.tsx
+++ b/internal/frontend/src/components/EmptyGroupMessage.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import type { Group } from "../hooks/useApi";
+
+interface EmptyGroupMessageProps {
+  group: Group | undefined;
+}
+
+function shellQuote(s: string): string {
+  if (/^[a-zA-Z0-9_\-./@]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+function buildUnwatchCommand(pattern: string, groupName: string): string {
+  const flag = groupName && groupName !== "default" ? ` -t ${shellQuote(groupName)}` : "";
+  return `mo --unwatch ${shellQuote(pattern)}${flag}`;
+}
+
+interface CommandRowProps {
+  command: string;
+}
+
+function CommandRow({ command }: CommandRowProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+    } catch {
+      // clipboard API may fail in insecure contexts
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2 w-full">
+      <code className="flex-1 px-3 py-2 bg-gh-bg-secondary border border-gh-border rounded text-xs text-gh-text font-mono overflow-x-auto whitespace-pre">
+        $ {command}
+      </code>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="shrink-0 flex items-center justify-center bg-transparent border border-gh-border rounded-md p-1.5 text-gh-text-secondary cursor-pointer transition-colors duration-150 hover:bg-gh-bg-hover"
+        title="Copy command"
+      >
+        {copied ? (
+          <svg
+            className="size-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+          </svg>
+        ) : (
+          <svg
+            className="size-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.75a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"
+            />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+}
+
+export function EmptyGroupMessage({ group }: EmptyGroupMessageProps) {
+  const patterns = group?.patterns ?? [];
+  const groupName = group?.name ?? "";
+
+  if (patterns.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-50 text-gh-text-secondary text-sm">
+        No file selected
+      </div>
+    );
+  }
+
+  const multiple = patterns.length > 1;
+
+  return (
+    <div className="flex flex-col items-start max-w-2xl mx-auto mt-12 p-6 text-gh-text-secondary text-sm gap-4">
+      <p className="text-gh-text font-semibold">No file in this group.</p>
+      <p>
+        This group is kept alive by the following watch pattern
+        {multiple ? "s" : ""}. Run the command{multiple ? "s" : ""} below to unwatch{" "}
+        {multiple ? "them" : "it"}. The group will disappear once all patterns are removed.
+      </p>
+      <div className="flex flex-col gap-2 w-full">
+        {patterns.map((p) => (
+          <CommandRow key={p} command={buildUnwatchCommand(p, groupName)} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/internal/frontend/src/hooks/useApi.ts
+++ b/internal/frontend/src/hooks/useApi.ts
@@ -9,6 +9,7 @@ export interface FileEntry {
 export interface Group {
   name: string;
   files: FileEntry[];
+  patterns?: string[];
 }
 
 export interface FileContent {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1606,12 +1606,12 @@ func handleGroups(state *State) http.HandlerFunc {
 		}
 		result := make([]statusGroup, len(groups))
 		for i, g := range groups {
-			// Normalize an empty Files slice (e.g. pattern-only group whose
-			// pattern currently matches zero files, where AddPattern left Files
-			// nil) so the JSON always encodes as `"files": []` instead of
-			// `"files": null`. The frontend assumes the field is always an
-			// array.
-			if len(g.Files) == 0 {
+			// Pattern-only groups created via AddPattern leave Files as nil,
+			// which encoding/json renders as `"files": null`. The frontend
+			// assumes the field is always an array, so swap a nil slice for
+			// an empty literal. An already-empty non-nil slice is left alone
+			// (encoding/json renders it as `[]` already).
+			if g.Files == nil {
 				g.Files = []*FileEntry{}
 			}
 			result[i] = statusGroup{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1606,6 +1606,13 @@ func handleGroups(state *State) http.HandlerFunc {
 		}
 		result := make([]statusGroup, len(groups))
 		for i, g := range groups {
+			// Normalize a nil Files slice (e.g. pattern-only group whose pattern
+			// currently matches zero files) to an empty slice so the JSON encodes
+			// as `"files": []` instead of `"files": null` — the frontend assumes
+			// the field is always an array.
+			if g.Files == nil {
+				g.Files = []*FileEntry{}
+			}
 			result[i] = statusGroup{
 				Group:    g,
 				Patterns: patternsByGroup[g.Name],

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1606,11 +1606,12 @@ func handleGroups(state *State) http.HandlerFunc {
 		}
 		result := make([]statusGroup, len(groups))
 		for i, g := range groups {
-			// Normalize a nil Files slice (e.g. pattern-only group whose pattern
-			// currently matches zero files) to an empty slice so the JSON encodes
-			// as `"files": []` instead of `"files": null` — the frontend assumes
-			// the field is always an array.
-			if g.Files == nil {
+			// Normalize an empty Files slice (e.g. pattern-only group whose
+			// pattern currently matches zero files, where AddPattern left Files
+			// nil) so the JSON always encodes as `"files": []` instead of
+			// `"files": null`. The frontend assumes the field is always an
+			// array.
+			if len(g.Files) == 0 {
 				g.Files = []*FileEntry{}
 			}
 			result[i] = statusGroup{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1600,8 +1600,15 @@ func handleReorderFiles(state *State) http.HandlerFunc {
 func handleGroups(state *State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		groups := state.Groups()
+		result := make([]statusGroup, len(groups))
+		for i, g := range groups {
+			result[i] = statusGroup{
+				Group:    g,
+				Patterns: state.PatternsForGroup(g.Name),
+			}
+		}
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(groups); err != nil {
+		if err := json.NewEncoder(w).Encode(result); err != nil {
 			slog.Error("failed to encode response", "error", err)
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1600,11 +1600,15 @@ func handleReorderFiles(state *State) http.HandlerFunc {
 func handleGroups(state *State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		groups := state.Groups()
+		patternsByGroup := make(map[string][]string)
+		for _, p := range state.Patterns() {
+			patternsByGroup[p.Group] = append(patternsByGroup[p.Group], p.Pattern)
+		}
 		result := make([]statusGroup, len(groups))
 		for i, g := range groups {
 			result[i] = statusGroup{
 				Group:    g,
-				Patterns: state.PatternsForGroup(g.Name),
+				Patterns: patternsByGroup[g.Name],
 			}
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2124,6 +2124,47 @@ func TestHandleGroups_IncludesPatterns(t *testing.T) {
 	}
 }
 
+func TestHandleGroups_FilesAlwaysArrayForPatternOnlyGroup(t *testing.T) {
+	s := newTestState(t)
+
+	// Pattern in an empty directory: AddPattern creates the group with a nil
+	// Files slice. Without normalization the JSON would encode as
+	// `"files": null`, which breaks the frontend's `group.files.length`.
+	dir := t.TempDir()
+	pattern := filepath.Join(dir, "*.md")
+	if _, err := s.AddPattern(pattern, DefaultGroup); err != nil {
+		t.Fatalf("AddPattern: %v", err)
+	}
+
+	handler := NewHandler(s)
+	req := httptest.NewRequest("GET", "/_/api/groups", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	raw := rec.Body.String()
+	if strings.Contains(raw, `"files":null`) {
+		t.Errorf("response contains \"files\":null, want \"files\":[]: %s", raw)
+	}
+
+	var groups []Group
+	if err := json.Unmarshal(rec.Body.Bytes(), &groups); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1", len(groups))
+	}
+	if groups[0].Files == nil {
+		t.Errorf("Files = nil, want empty slice")
+	}
+	if len(groups[0].Files) != 0 {
+		t.Errorf("len(Files) = %d, want 0", len(groups[0].Files))
+	}
+}
+
 func TestCSPHeader(t *testing.T) {
 	s := newTestState(t)
 	handler := NewHandler(s)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2157,9 +2157,6 @@ func TestHandleGroups_FilesAlwaysArrayForPatternOnlyGroup(t *testing.T) {
 	if len(groups) != 1 {
 		t.Fatalf("got %d groups, want 1", len(groups))
 	}
-	if groups[0].Files == nil {
-		t.Errorf("Files = nil, want empty slice")
-	}
 	if len(groups[0].Files) != 0 {
 		t.Errorf("len(Files) = %d, want 0", len(groups[0].Files))
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2055,6 +2055,75 @@ func TestHandleGroups_IncludesTitle(t *testing.T) {
 	}
 }
 
+func TestHandleGroups_IncludesPatterns(t *testing.T) {
+	s := newTestState(t)
+
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "a.md"), []byte("# A"), 0o600) //nolint:errcheck
+	pattern := filepath.Join(dir, "*.md")
+	if _, err := s.AddPattern(pattern, DefaultGroup); err != nil {
+		t.Fatalf("AddPattern: %v", err)
+	}
+
+	plainDir := t.TempDir()
+	plainFile := filepath.Join(plainDir, "plain.md")
+	os.WriteFile(plainFile, []byte("# Plain"), 0o600) //nolint:errcheck
+	if _, err := s.AddFile(plainFile, "docs"); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+
+	handler := NewHandler(s)
+	req := httptest.NewRequest("GET", "/_/api/groups", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	rawBody := rec.Body.Bytes()
+	var groups []struct {
+		Name     string   `json:"name"`
+		Patterns []string `json:"patterns,omitempty"`
+	}
+	if err := json.Unmarshal(rawBody, &groups); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	byName := make(map[string][]string, len(groups))
+	for _, g := range groups {
+		byName[g.Name] = g.Patterns
+	}
+
+	got, ok := byName[DefaultGroup]
+	if !ok {
+		t.Fatalf("default group missing from response: %+v", groups)
+	}
+	if len(got) != 1 || got[0] != pattern {
+		t.Errorf("default group patterns = %v, want [%s]", got, pattern)
+	}
+
+	if pats, ok := byName["docs"]; !ok {
+		t.Errorf("docs group missing from response: %+v", groups)
+	} else if len(pats) != 0 {
+		t.Errorf("docs group patterns = %v, want omitted (group has no patterns)", pats)
+	}
+
+	// Verify `omitempty`: docs has no patterns so the JSON key should be absent.
+	var rawGroups []map[string]json.RawMessage
+	if err := json.Unmarshal(rawBody, &rawGroups); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	for _, g := range rawGroups {
+		name := strings.Trim(string(g["name"]), `"`)
+		if name == "docs" {
+			if _, has := g["patterns"]; has {
+				t.Errorf("expected omitempty for docs group, but patterns key is present: %s", rawBody)
+			}
+		}
+	}
+}
+
 func TestCSPHeader(t *testing.T) {
 	s := newTestState(t)
 	handler := NewHandler(s)


### PR DESCRIPTION
## Summary

A group with no files but a registered watch pattern stays alive (groups persist as long as they have files _or_ patterns), so when the last file is closed the content area falls back to a bare "No file selected" message. Nothing tells the user why the group still exists or how to retire it, even though that information — the watch patterns — is already known on the server.

### Motivation

The "kept alive by pattern" state is invisible from the UI: the sidebar shows an empty file list, the group dropdown still lists the group, and the only hint that something is anchoring it lives in `--status` output on the CLI. A user who wants the group gone has to remember the exact `mo --unwatch` invocation themselves, which the UI is in a much better position to provide.

## Changes

- `internal/server/server.go`: `GET /_/api/groups` now returns the existing `statusGroup` shape, so each entry carries its registered `patterns` alongside `files`. The `/_/api/status` payload is unchanged.
- `internal/frontend/src/hooks/useApi.ts`: extend `Group` with optional `patterns: string[]`.
- `internal/frontend/src/components/EmptyGroupMessage.tsx` (new): when the active group has zero files but one or more patterns, render the patterns as a ready-to-copy `mo --unwatch '<pattern>'[ -t <group>]` command per row, each with a clipboard-copy button. Glob metacharacters are shell-quoted so a paste into the shell survives unmodified, and the `-t <group>` flag is appended only when the group is not the default. When `patterns` is empty the previous "No file selected" rendering is preserved.
- `internal/frontend/src/App.tsx`: derive `activeGroupData` from `groups` and feed it to `EmptyGroupMessage` in place of the inline empty state.

## Verification

- `go test ./...` (all packages green)
- `cd internal/frontend && pnpm test` (24 files / 242 tests pass)
- `make lint` (oxfmt, oxlint, golangci-lint, gostyle all clean)
- End-to-end with `make dev ARGS="-w 'testdata/*.md'"`: removed every file via `DELETE /_/api/groups/default/files/{id}` to drive the group to `files: []` while the pattern remained, then loaded the SPA and confirmed `EmptyGroupMessage` rendered the pattern and the `mo --unwatch '<absolute-glob>'` command with a working Copy button.