### PR TITLE
fix(frontend): make the Mermaid copy-image button work in Chrome/Safari and on HTML-label diagrams

### DIFF
--- a/internal/frontend/src/components/MarkdownViewer.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.tsx
@@ -260,11 +260,15 @@ function MermaidImageCopyButton({ svg }: { svg: string }) {
 
   const handleCopy = async () => {
     try {
-      const blob = await svgToPngBlob(svg);
-      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+      // Pass the Blob promise directly to ClipboardItem so clipboard.write() is
+      // invoked synchronously inside the user gesture. Awaiting the blob first
+      // lets the transient user activation expire on Chrome and breaks the
+      // user-gesture requirement on Safari/WebKit, both surfacing as a silent
+      // no-op click.
+      await navigator.clipboard.write([new ClipboardItem({ "image/png": svgToPngBlob(svg) })]);
       setCopied(true);
-    } catch {
-      // clipboard API may fail in insecure contexts
+    } catch (err) {
+      console.error("mermaid copy image failed", err);
     }
   };
 

--- a/internal/frontend/src/components/MarkdownViewer.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.tsx
@@ -300,9 +300,20 @@ function MermaidImageCopyButton({ svg }: { svg: string }) {
 
 function svgToPngBlob(svgString: string): Promise<Blob> {
   return new Promise((resolve, reject) => {
+    // Mermaid flowchart/stateDiagram labels embed HTML void elements such as
+    // <br> inside <foreignObject>, which the strict "image/svg+xml" parser
+    // rejects silently (documentElement becomes <html> and the width, height,
+    // and viewBox lookups all return null). Parsing as "text/html" is lenient
+    // and still preserves the case of SVG attributes (viewBox,
+    // preserveAspectRatio, etc.). XMLSerializer then normalizes <br> to <br/>
+    // so the resulting data URL loads cleanly as an SVG image.
     const parser = new DOMParser();
-    const doc = parser.parseFromString(svgString, "image/svg+xml");
-    const svgEl = doc.documentElement;
+    const doc = parser.parseFromString(svgString, "text/html");
+    const svgEl = doc.querySelector("svg");
+    if (!svgEl) {
+      reject(new Error("No SVG element found"));
+      return;
+    }
 
     // Ensure xmlns is present for standalone SVG rendering
     if (!svgEl.getAttribute("xmlns")) {


### PR DESCRIPTION
## Summary

The "Copy image" button on Mermaid blocks looked broken in two distinct ways: on Safari/WebKit it never copied anything, and on Chrome it only worked for sequence diagrams while silently doing nothing on flowcharts and state diagrams. Both failures landed in the same `catch {}` and never surfaced anywhere visible, so the feature read as "sometimes works, no error in DevTools, no indication why."

There were two independent root causes and one usability problem stacked on top of each other.

### Motivation

**Root cause 1: the click handler lost its user gesture.**
`handleCopy` awaited `svgToPngBlob(svg)` before calling `navigator.clipboard.write()`. Rasterizing the SVG via `new Image()` + `<canvas>` is fully async and takes long enough that the click's transient user activation can expire on Chrome before `write()` runs. Safari is stricter and rejects the write outright with "The request is not allowed by the user agent or the platform in the current context."

**Root cause 2: the strict XML parser rejected flowchart SVGs.**
`svgToPngBlob` called `DOMParser.parseFromString(svgString, "image/svg+xml")`, which is a strict XML parse. Mermaid emits HTML void elements (`<br>`) inside `<foreignObject>` when rendering multi-line labels for flowcharts and state diagrams; the unmatched `<br>` makes XML parsing fail, leaving `documentElement` as `<html>` and every `getAttribute("width" / "height" / "viewBox")` returning `null`. The function then rejected with "Cannot determine SVG dimensions". Sequence diagrams use SVG `<text>` rather than `foreignObject` and were unaffected, which is why the bug looked inconsistent.

**Usability: `catch {}` swallowed both failures.**
The original handler dropped every error silently, so a user clicking the button saw nothing happen and DevTools stayed empty.

## Changes

- `internal/frontend/src/components/MarkdownViewer.tsx` (`handleCopy`): pass `svgToPngBlob(svg)` as a `Promise<Blob>` directly into `new ClipboardItem({ "image/png": ... })`. The spec lets ClipboardItem hold an unresolved Blob, so `clipboard.write()` runs synchronously inside the click handler and the user-gesture requirement is satisfied regardless of how long the SVG to PNG conversion takes. Surface the error on the console instead of swallowing it.
- `internal/frontend/src/components/MarkdownViewer.tsx` (`svgToPngBlob`): switch `DOMParser` to `"text/html"`. The HTML parser is lenient about `<br>` but still preserves the case of SVG attributes (`viewBox` stays `viewBox`) for an `<svg>` root, so the dimension lookups keep working. `XMLSerializer` then rewrites `<br>` to `<br/>` on the way to the data URL, which is what the browser's `<img>` SVG loader needs. Use `querySelector("svg")` to fetch the SVG node and reject early when it is missing.

## Verification

- `cd internal/frontend && pnpm test` (all 25 files / 254 tests pass)
- `make lint` plus `pnpm run fmt:check` (clean)
- End-to-end against the embedded binary served on `localhost:16275` with a real document containing 10 Mermaid blocks (flowchart, sequence, stateDiagram, with multi-line `<br>` labels). Both Chrome and WebKit copy all 10 blocks successfully; the resulting PNG renders the multi-line labels correctly. Before this PR Chrome failed 4 of 10 (flowchart + stateDiagram) with `Cannot determine SVG dimensions`, and Safari failed every one with the user-gesture rejection.