### PR TITLE
fix(frontend): render base64 data:image URIs in Markdown images

### DIFF
--- a/internal/frontend/src/components/MarkdownViewer.test.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.test.tsx
@@ -117,6 +117,34 @@ describe("MarkdownViewer file label", () => {
   });
 });
 
+describe("MarkdownViewer images", () => {
+  const pngDataUri =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==";
+
+  it("renders a data:image URI through the sanitizer unchanged", async () => {
+    vi.mocked(fetchFileContent).mockResolvedValue({
+      content: `![embedded](${pngDataUri})`,
+      baseDir: "/repo",
+    });
+    renderViewer();
+    const img = await screen.findByRole("img", { name: "embedded" });
+    expect(img).toHaveAttribute("src", pngDataUri);
+  });
+
+  it("rewrites a relative image src to the raw API path", async () => {
+    vi.mocked(fetchFileContent).mockResolvedValue({
+      content: "![diagram](images/diagram.png)",
+      baseDir: "/repo",
+    });
+    renderViewer();
+    const img = await screen.findByRole("img", { name: "diagram" });
+    expect(img).toHaveAttribute(
+      "src",
+      "/_/api/groups/default/files/aaa11111/raw/images/diagram.png",
+    );
+  });
+});
+
 describe("MarkdownViewer relative links", () => {
   beforeEach(() => {
     vi.mocked(fetchFileContent).mockResolvedValue({

--- a/internal/frontend/src/components/MarkdownViewer.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState, useCallback, useMemo } from "react";
-import Markdown from "react-markdown";
+import Markdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeRaw from "rehype-raw";
@@ -62,7 +62,21 @@ const sanitizeSchema = {
     span: [...(defaultSchema.attributes?.["span"] || []), "style"],
     div: [...(defaultSchema.attributes?.["div"] || []), "style", "align"],
   },
+  protocols: {
+    ...defaultSchema.protocols,
+    src: [...(defaultSchema.protocols?.["src"] || []), "data"],
+  },
 };
+
+// react-markdown's defaultUrlTransform drops every data: URI, on top of
+// rehype-sanitize. Restrict the exception to data:image/ on src: img is
+// script-inert for data URIs, while data:text/html on href would be a vector.
+function urlTransform(url: string, key: string): string {
+  if (key === "src" && url.startsWith("data:image/")) {
+    return url;
+  }
+  return defaultUrlTransform(url);
+}
 
 interface MarkdownViewerProps {
   fileId: string;
@@ -751,6 +765,7 @@ export function MarkdownViewer({
             rehypeKatex,
           ]}
           components={components}
+          urlTransform={urlTransform}
         >
           {md}
         </Markdown>

--- a/internal/frontend/src/utils/resolve.test.ts
+++ b/internal/frontend/src/utils/resolve.test.ts
@@ -125,6 +125,18 @@ describe("resolveImageSrc", () => {
   it("returns undefined for undefined src", () => {
     expect(resolveImageSrc(undefined, "default", "a")).toBeUndefined();
   });
+
+  it("passes through data:image/ URIs unchanged", () => {
+    const src =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==";
+    expect(resolveImageSrc(src, "default", "a")).toBe(src);
+  });
+
+  it("does not pass through non-image data: URIs", () => {
+    expect(resolveImageSrc("data:text/html,<script>alert(1)</script>", "default", "c")).toBe(
+      "/_/api/groups/default/files/c/raw/data:text/html,<script>alert(1)</script>",
+    );
+  });
 });
 
 describe("extractLanguage", () => {

--- a/internal/frontend/src/utils/resolve.ts
+++ b/internal/frontend/src/utils/resolve.ts
@@ -36,6 +36,11 @@ export function resolveImageSrc(
   group: string,
   fileId: string,
 ): string | undefined {
+  // Only data:image/ passes through: rehype-sanitize can whitelist the "data" scheme
+  // but not the MIME type, so restrict it here as defense in depth.
+  if (src && src.startsWith("data:image/")) {
+    return src;
+  }
   if (src && !src.startsWith("http://") && !src.startsWith("https://")) {
     return `${rawBasePath(group, fileId)}/${src}`;
   }


### PR DESCRIPTION
## Summary

Markdown images with base64-embedded data URIs (`![alt](data:image/png;base64,...)`) never rendered. #230 identified two culprits, but fixing those alone was not enough — a third layer, react-markdown's own `defaultUrlTransform`, empties every `data:` URI even after rehype-sanitize passes it through.

### Motivation

Three independent layers each broke data URIs:

1. **`resolveImageSrc()`** treated any non-http(s) src as a relative path and prepended the `/_/api/.../raw/` prefix, mangling the URI.
2. **`rehype-sanitize`**'s default schema only allows `http`/`https` for `src`, so the attribute was stripped.
3. **`react-markdown`'s `defaultUrlTransform`** replaces every `data:` URI with an empty string as its own URL-safety layer. This one only surfaced once a pipeline-level test rendered a data URI through the real react-markdown stack — the img came out with an empty `src` despite fixes 1 and 2.

The exception is deliberately narrow: only `data:image/` and only on `src`. rehype-sanitize can whitelist the `data` scheme but cannot filter by MIME type, so the MIME restriction is enforced at the `resolveImageSrc` and `urlTransform` layers instead. `img` is script-inert for data URIs (scripts inside SVG-as-image do not execute), while `data:text/html` on `href` would be a navigation vector — `href` protocols stay untouched. The server CSP already permits `img-src data:`, so no backend change is needed.

## Changes

- `internal/frontend/src/utils/resolve.ts` (`resolveImageSrc`): pass `data:image/` URIs through unchanged instead of prepending the raw asset prefix. Other `data:` URIs keep the current (inert) relative-path behavior.
- `internal/frontend/src/components/MarkdownViewer.tsx`: extend `sanitizeSchema` with `protocols.src: [http, https, data]`, and add a `urlTransform` that admits `data:image/` on `src` and defers everything else to `defaultUrlTransform`.
- `internal/frontend/src/utils/resolve.test.ts`: cover both directions — `data:image/png` passes through, `data:text/html` does not.
- `internal/frontend/src/components/MarkdownViewer.test.tsx`: pipeline-level tests rendering through the real react-markdown + rehype-sanitize + urlTransform stack — a `data:image/png` URI survives to the rendered `<img src>`, and a relative image src is still rewritten to the raw API path.

## Verification

- `cd internal/frontend && pnpm test` (25 files / 258 tests pass)
- `make lint` and `go test ./...` (clean)
- End-to-end via `make dev` against the embedded binary on `localhost:16275`, driven with Chrome: a document with a 64×64 base64 PNG renders the image (`naturalWidth: 64`, decoded), while an `![...](data:text/html,...)` img ends up with no usable `src` and stays inert.

Closes #230