### PR TITLE
Fix data race in State.Groups() by deep-copying FileEntry values

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -383,9 +383,23 @@ func (s *State) Groups() []Group {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	// Deep-copy each Group and its FileEntry pointers while holding the lock
+	// so callers (e.g. JSON encoding after the lock is released) never share
+	// state with in-place mutations such as notifyFileChangedByPath's Title
+	// updates or RemoveFilesByPath's slice compaction.
 	result := make([]Group, 0, len(s.groups))
 	for _, g := range s.groups {
-		result = append(result, *g)
+		var files []*FileEntry
+		if g.Files != nil {
+			files = make([]*FileEntry, len(g.Files))
+			for i, f := range g.Files {
+				fc := *f
+				files[i] = &fc
+			}
+		}
+		gc := *g
+		gc.Files = files
+		result = append(result, gc)
 	}
 	return result
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2447,6 +2447,11 @@ func TestGroupsReturnsDeepCopies(t *testing.T) {
 	}
 
 	// (a) Mutating a returned FileEntry's fields must not affect internal state.
+	// Capture the expected values before mutating: entry aliases internal
+	// state, so comparing against entry after the mutation would be
+	// tautological if Groups() leaked shared pointers.
+	wantTitle := entry.Title
+	wantName := entry.Name
 	groups[0].Files[0].Title = "mutated-title"
 	groups[0].Files[0].Name = "mutated-name"
 
@@ -2454,11 +2459,11 @@ func TestGroupsReturnsDeepCopies(t *testing.T) {
 	if len(again) != 1 || len(again[0].Files) != 1 {
 		t.Fatalf("unexpected state after mutation: %+v", again)
 	}
-	if again[0].Files[0].Title != entry.Title {
-		t.Fatalf("internal Title mutated via returned copy: got %q, want %q", again[0].Files[0].Title, entry.Title)
+	if again[0].Files[0].Title != wantTitle {
+		t.Fatalf("internal Title mutated via returned copy: got %q, want %q", again[0].Files[0].Title, wantTitle)
 	}
-	if again[0].Files[0].Name != entry.Name {
-		t.Fatalf("internal Name mutated via returned copy: got %q, want %q", again[0].Files[0].Name, entry.Name)
+	if again[0].Files[0].Name != wantName {
+		t.Fatalf("internal Name mutated via returned copy: got %q, want %q", again[0].Files[0].Name, wantName)
 	}
 
 	// (b) The returned Files slice must have its own backing array: replacing

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2377,3 +2377,103 @@ func TestHandleFileRaw_PercentEncodedNonASCII(t *testing.T) {
 		t.Errorf("expected body to contain %q, got %q", "asset content", got)
 	}
 }
+
+// Regression test: Groups() must return deep copies so JSON encoding does
+// not race with Title updates from the file watcher.
+func TestGroupsRaceWithTitleUpdate(t *testing.T) {
+	s := newTestState(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "race.md")
+	if err := os.WriteFile(path, []byte("# title-0\n\nbody\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AddFile(path, DefaultGroup); err != nil {
+		t.Fatal(err)
+	}
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Reader: mimics handleGroups / handleStatus — encode after the lock is released.
+	go func() {
+		defer wg.Done()
+		enc := json.NewEncoder(io.Discard)
+		for range iterations {
+			groups := s.Groups()
+			if err := enc.Encode(groups); err != nil {
+				t.Error(err)
+				return
+			}
+		}
+	}()
+
+	// Writer: mimics the fsnotify path — rewrite the H1 so Title always changes.
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			content := fmt.Sprintf("# title-%d\n\nbody\n", i+1)
+			if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+				t.Error(err)
+				return
+			}
+			s.notifyFileChangedByPath(path)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestGroupsReturnsDeepCopies verifies that Groups() returns FileEntry copies
+// that are independent of internal state: mutating the returned FileEntry
+// values or the returned Files slice must not affect subsequent Groups() calls.
+func TestGroupsReturnsDeepCopies(t *testing.T) {
+	s := newTestState(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deepcopy.md")
+	if err := os.WriteFile(path, []byte("# original-title\n\nbody\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	entry, err := s.AddFile(path, DefaultGroup)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	groups := s.Groups()
+	if len(groups) != 1 || len(groups[0].Files) != 1 {
+		t.Fatalf("unexpected initial state: %+v", groups)
+	}
+
+	// (a) Mutating a returned FileEntry's fields must not affect internal state.
+	groups[0].Files[0].Title = "mutated-title"
+	groups[0].Files[0].Name = "mutated-name"
+
+	again := s.Groups()
+	if len(again) != 1 || len(again[0].Files) != 1 {
+		t.Fatalf("unexpected state after mutation: %+v", again)
+	}
+	if again[0].Files[0].Title != entry.Title {
+		t.Fatalf("internal Title mutated via returned copy: got %q, want %q", again[0].Files[0].Title, entry.Title)
+	}
+	if again[0].Files[0].Name != entry.Name {
+		t.Fatalf("internal Name mutated via returned copy: got %q, want %q", again[0].Files[0].Name, entry.Name)
+	}
+
+	// (b) The returned Files slice must have its own backing array: replacing
+	// an element in the returned slice must not affect internal state.
+	groups2 := s.Groups()
+	groups2[0].Files[0] = &FileEntry{ID: "injected", Name: "injected.md"}
+
+	final := s.Groups()
+	if len(final) != 1 || len(final[0].Files) != 1 {
+		t.Fatalf("unexpected state after slice element replacement: %+v", final)
+	}
+	if final[0].Files[0].ID == "injected" {
+		t.Fatal("internal Files backing array mutated via returned slice")
+	}
+	if final[0].Files[0].ID != entry.ID {
+		t.Fatalf("got file ID %q, want %q", final[0].Files[0].ID, entry.ID)
+	}
+}


### PR DESCRIPTION
## Problem

`State.Groups()` copies each `Group` by value, but `Group.Files` is a `[]*FileEntry`, so the returned copies still share the same `*FileEntry` pointers and backing array with internal state. This causes a data race:

- **Read side**: `handleGroups` / `handleStatus` / `handleSearch` call `state.Groups()`, then JSON-encode the result *after* `s.mu` has been released, reading `FileEntry.Title` through the shared pointers.
- **Write side**: `notifyFileChangedByPath` (triggered by the fsnotify watcher) updates `entry.Title` under `s.mu`.

Since the read happens outside the lock through shared pointers, `s.mu` does not protect it. `go test -race` deterministically reports the race (write in `notifyFileChangedByPath` vs. read in `encoding/json`):

```
WARNING: DATA RACE
Write at 0x00c0001708d0 by goroutine 11:
  github.com/k1LoW/mo/internal/server.(*State).notifyFileChangedByPath()
      internal/server/server.go:1074
Previous read at 0x00c0001708d0 by goroutine 10:
  encoding/json.structEncoder.encode()
  ... (JSON encoding of a State.Groups() result)
```

It can be hit in normal use: keep `/_/api/groups` (or `/_/api/status`, `/_/api/search`) polling while saving edits to a watched file's H1 so its `Title` changes.

Additionally, `RemoveFilesByPath` compacts the shared backing array in place (`filtered := g.Files[:0]` + nil-filling the tail), so a copy obtained from `Groups()` could observe nil slots or partially overwritten pointers while being encoded concurrently.

## Fix

Deep-copy while holding the lock: `Groups()` now allocates a fresh `Files` slice per group and value-copies each `FileEntry` into a new pointer. `FileEntry` contains only string/bool value fields, so a struct value copy is a complete deep copy. A `nil` `Files` slice is preserved as `nil` to keep `handleGroups`'s existing `nil` → `[]` substitution behavior unchanged.

This single change fixes both the `Title` race and the backing-array sharing with `RemoveFilesByPath`, since all affected handlers go through `Groups()`.

`FindFile` is intentionally left unchanged: its callers only read fields that are immutable after creation (`Path`, `Uploaded`, `content`), so there is no race there today, and keeping the diff minimal seemed preferable.

## Tests

- `TestGroupsRaceWithTitleUpdate` (regression): one goroutine JSON-encodes `Groups()` results while another rewrites the file's H1 and calls `notifyFileChangedByPath`. Deterministically failed under `-race` before the fix; passes now.
- `TestGroupsReturnsDeepCopies`: verifies that mutating returned `FileEntry` values or returned slice elements does not affect internal state (both checks were verified to fail against the pre-fix implementation).

## Verification

- `go test -race ./internal/server/` — all pass, no race reports
- `go test ./...` — all pass
- `golangci-lint run ./...` — 0 issues
- `gostyle run --config .gostyle.yml ./...` — clean
- `gofmt` / `go vet` — clean
- CI (test matrix ubuntu/macos + lint + license check) green on my fork: kiakiraki/mo#11

🤖 Generated with [Claude Code](https://claude.com/claude-code)