### PR TITLE
Fix background start falsely reporting success when the server fails to start

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,10 +42,18 @@ const (
 	probeTimeoutFast = 500 * time.Millisecond
 	// probeTimeoutDefault is used when the server is expected to be running.
 	probeTimeoutDefault = 2 * time.Second
+	// deadChildGrace is how long waitForReady keeps polling after the spawned
+	// child dies, giving a race-winning server a chance to respond before the
+	// failure is reported.
+	deadChildGrace = 1 * time.Second
 
 	markdownGlob          = "*.md"
 	markdownGlobRecursive = "**/*.md"
 )
+
+// errServerConflict is returned by waitForReady when a mo server other than
+// the spawned child owns the port (e.g. lost a concurrent startup race).
+var errServerConflict = errors.New("another mo server is already running")
 
 var (
 	target                       string
@@ -203,13 +211,23 @@ func init() {
 	rootCmd.Flags().BoolVar(&dangerouslyAllowRemoteAccess, "dangerously-allow-remote-access", false, "Allow remote access without authentication. Recommended only for trusted networks.")
 }
 
-func run(cmd *cobra.Command, args []string) error {
+func run(cmd *cobra.Command, args []string) (retErr error) {
 	if !foreground || restore != "" {
 		logCleanup, err := logfile.Setup(port)
 		if err != nil {
 			slog.Warn("failed to setup log file, using stderr", "error", err)
 		} else {
 			defer logCleanup()
+			// Cobra prints RunE errors to stderr, which is /dev/null for
+			// background children. Record fatal errors in the log file too
+			// (registered after logCleanup so it runs before the file is
+			// closed). Skipped when slog still writes to stderr, where cobra
+			// prints the error anyway.
+			defer func() {
+				if retErr != nil {
+					slog.Error("mo exited with error", "error", retErr)
+				}
+			}()
 		}
 	}
 
@@ -1368,6 +1386,9 @@ func startServer(ctx context.Context, addr string, filesByGroup map[string][]str
 
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
+		// The CloseAllSubscribers cleanup below is not yet registered; close the
+		// watcher here so watchLoop exits and donegroup does not hit its 5s timeout.
+		state.CloseAllSubscribers()
 		return fmt.Errorf("cannot listen on %s: %w", addr, err)
 	}
 
@@ -1453,9 +1474,21 @@ func startBackground(addr string, filesByGroup map[string][]string, patternsByGr
 		slog.Warn("failed to release process", "error", err)
 	}
 
-	status, err := waitForReady(addr, 10*time.Second)
+	status, err := waitForReady(addr, pid, 10*time.Second)
 	if err != nil {
-		return fmt.Errorf("%w (pid %d)", err, pid)
+		// Remove the restore file only once the child is confirmed dead: a
+		// slow-but-alive child may not have consumed it yet, and an alive
+		// child removes it itself after loading.
+		if !processAlive(pid) {
+			os.Remove(restoreFile) //nolint:errcheck // best-effort; the child may have consumed it already
+		}
+		if errors.Is(err, errServerConflict) {
+			// Lost a concurrent startup race: another mo server owns the
+			// port. Add our files to the winner instead of reporting a
+			// false success.
+			return addToRunningServer(addr, status, filesByGroup, patternsByGroup, uploadedFiles)
+		}
+		return fmt.Errorf("%w (spawned pid %d)", err, pid)
 	}
 
 	var deeplinks []deeplinkEntry
@@ -1478,6 +1511,57 @@ func startBackground(addr string, filesByGroup map[string][]string, patternsByGr
 	return nil
 }
 
+// addToRunningServer posts files, patterns, and uploaded files to a mo server
+// that is already running on addr. Used when a background start loses the
+// port to another mo instance (concurrent startup race).
+func addToRunningServer(addr string, status *statusResponse, filesByGroup map[string][]string, patternsByGroup map[string][]string, uploadedFiles []server.UploadedFileData) error {
+	slog.Info("port already served by another mo instance; adding to it", "addr", addr, "pid", status.PID)
+	client := &http.Client{Timeout: probeTimeoutDefault}
+	var deeplinks []deeplinkEntry
+	added := 0
+	attempted := 0
+	for group, files := range filesByGroup {
+		attempted += len(files)
+		entries := postFiles(client, addr, group, files)
+		deeplinks = append(deeplinks, entries...)
+		added += len(entries)
+	}
+	for group, patterns := range patternsByGroup {
+		// A pattern may legitimately match zero files, so count patterns as
+		// added rather than by returned entries.
+		attempted += len(patterns)
+		deeplinks = append(deeplinks, postPatterns(client, addr, group, patterns)...)
+		added += len(patterns)
+	}
+	for _, uf := range uploadedFiles {
+		attempted++
+		entry, err := postUploadedFile(client, addr, uf.Group, uf.Name, uf.Content)
+		if err != nil {
+			slog.Warn("failed to upload file", "name", uf.Name, "error", err)
+			continue
+		}
+		deeplinks = append(deeplinks, entry)
+		added++
+	}
+	if attempted > 0 && added == 0 {
+		return fmt.Errorf("failed to add any items to the mo server at http://%s (check log file for details)", addr)
+	}
+	emitServeOutput(addr, deeplinks, true)
+	fmt.Fprintf(os.Stderr, "mo: another mo server is already running at http://%s (pid %d); added %d item(s) to it\n", addr, status.PID, added)
+
+	isNewGroup := true
+	for _, g := range status.Groups {
+		if g.Name == target {
+			isNewGroup = false
+			break
+		}
+	}
+	if isNewGroup || open {
+		openBrowser(addr)
+	}
+	return nil
+}
+
 func openBrowser(addr string) {
 	if noOpen {
 		return
@@ -1491,26 +1575,45 @@ func openBrowser(addr string) {
 	}
 }
 
-func waitForReady(addr string, timeout time.Duration) (*statusResponse, error) {
+// waitForReady polls addr until a mo server responds as ready, the spawned
+// child (childPID) dies, or timeout elapses.
+//
+// If a mo server responds but its PID does not match childPID, the spawned
+// child lost a concurrent startup race for the port; errServerConflict is
+// returned along with the winning server's status.
+func waitForReady(addr string, childPID int, timeout time.Duration) (*statusResponse, error) {
 	client := &http.Client{Timeout: 500 * time.Millisecond}
 	deadline := time.Now().Add(timeout)
 
+	var childDeadSince time.Time
 	for time.Now().Before(deadline) {
 		resp, err := client.Get(fmt.Sprintf("http://%s/_/api/status", addr))
 		if err == nil {
 			if resp.StatusCode == http.StatusOK {
 				var status statusResponse
-				if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+				if decErr := json.NewDecoder(resp.Body).Decode(&status); decErr == nil && status.Version != "" {
 					resp.Body.Close()
-					return nil, nil //nolint:nilerr // decode failure is non-fatal; server is ready
+					if childPID > 0 && status.PID != childPID {
+						return &status, errServerConflict
+					}
+					return &status, nil
 				}
-				resp.Body.Close()
-				return &status, nil
 			}
 			resp.Body.Close()
 		}
+
+		// Not ready yet: if the spawned child has died, keep polling briefly —
+		// in a lost startup race the winner may not be serving yet — then fail
+		// fast instead of waiting out the full timeout.
+		if childPID > 0 && childDeadSince.IsZero() && !processAlive(childPID) {
+			childDeadSince = time.Now()
+		}
+		if !childDeadSince.IsZero() && time.Since(childDeadSince) >= deadChildGrace {
+			return nil, errors.New("server process exited unexpectedly; the port may be in use by another server (check log file for details)")
+		}
+
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	return nil, fmt.Errorf("server did not become ready within %s (check log file for details)", timeout)
+	return nil, fmt.Errorf("server did not become ready within %s; the port may be in use by another (non-mo) server (check log file for details)", timeout)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,10 +3,14 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -839,6 +843,178 @@ func newFakeMoServer(t *testing.T, statusHandler http.HandlerFunc) *httptest.Ser
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func TestWaitForReady_Success(t *testing.T) {
+	pid := os.Getpid()
+	srv := newFakeMoServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"version": "test", "pid": pid, "groups": []any{}}) //nolint:errcheck
+	})
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	status, err := waitForReady(addr, pid, 2*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status == nil {
+		t.Fatal("expected non-nil status")
+	}
+	if status.PID != pid {
+		t.Fatalf("got PID %d, want %d", status.PID, pid)
+	}
+}
+
+func TestWaitForReady_PIDMismatch(t *testing.T) {
+	childPID := os.Getpid()
+	otherPID := childPID + 1
+	srv := newFakeMoServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"version": "test", "pid": otherPID, "groups": []any{}}) //nolint:errcheck
+	})
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	status, err := waitForReady(addr, childPID, 2*time.Second)
+	if !errors.Is(err, errServerConflict) {
+		t.Fatalf("got error %v, want errServerConflict", err)
+	}
+	if status == nil {
+		t.Fatal("expected non-nil status")
+	}
+}
+
+func TestWaitForReady_NonMoServer(t *testing.T) {
+	childPID := os.Getpid()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /_/api/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, "<html>not mo</html>")
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	_, err := waitForReady(addr, childPID, 300*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "did not become ready") {
+		t.Fatalf("got error %q, want 'did not become ready'", err.Error())
+	}
+}
+
+func TestWaitForReady_ChildExited(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires the Unix 'true' binary")
+	}
+	// Start a child without waiting: it exits immediately but stays a zombie,
+	// so its pid cannot be reused and processAlive's non-blocking reap is
+	// what detects the death (same as a real spawned server child).
+	exited := exec.Command("true")
+	if err := exited.Start(); err != nil {
+		t.Fatalf("failed to start helper process: %v", err)
+	}
+	deadPID := exited.Process.Pid
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /_/api/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, "<html>not mo</html>")
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	start := time.Now()
+	_, err := waitForReady(addr, deadPID, 5*time.Second)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exited unexpectedly") {
+		t.Fatalf("got error %q, want 'exited unexpectedly'", err.Error())
+	}
+	// Death detection plus the deadChildGrace window should still finish
+	// well before the 5s timeout.
+	if elapsed > 3*time.Second {
+		t.Fatalf("waitForReady took %s, want fail-fast (<3s)", elapsed)
+	}
+}
+
+func TestProcessAlive_ZombieChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("zombie processes are a Unix concept")
+	}
+	// Start a child and do not Wait: after exit it stays a zombie, for which
+	// kill(pid, 0) still succeeds. processAlive must detect it as dead.
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start helper process: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processAlive(pid) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("processAlive still reports true for exited (zombie) child after 2s")
+}
+
+func TestAddToRunningServer(t *testing.T) {
+	origNoOpen := noOpen
+	noOpen = true
+	t.Cleanup(func() { noOpen = origNoOpen })
+
+	var postCount int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /_/api/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"version": "test", "pid": 12345, "groups": []any{}}) //nolint:errcheck
+	})
+	mux.HandleFunc("POST /_/api/groups/{group}/files", func(w http.ResponseWriter, r *http.Request) {
+		postCount++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(server.FileEntry{ID: "abc12345", Path: "/tmp/x.md", Name: "x.md"}) //nolint:errcheck
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	status := &statusResponse{PID: 12345}
+	err := addToRunningServer(addr, status, map[string][]string{"default": {"/tmp/x.md"}}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if postCount != 1 {
+		t.Fatalf("got %d POSTs, want 1", postCount)
+	}
+}
+
+func TestAddToRunningServer_AllPostsFail(t *testing.T) {
+	origNoOpen := noOpen
+	noOpen = true
+	t.Cleanup(func() { noOpen = origNoOpen })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /_/api/groups/{group}/files", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "shutting down", http.StatusServiceUnavailable)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	status := &statusResponse{PID: 12345}
+	err := addToRunningServer(addr, status, map[string][]string{"default": {"/tmp/x.md"}}, nil, nil)
+	if err == nil {
+		t.Fatal("expected error when every POST fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to add any items") {
+		t.Fatalf("got error %q, want 'failed to add any items'", err.Error())
+	}
 }
 
 func TestIsLoopbackBind(t *testing.T) {

--- a/cmd/sysprocattr_unix.go
+++ b/cmd/sysprocattr_unix.go
@@ -3,10 +3,29 @@
 package cmd
 
 import (
+	"errors"
 	"os/exec"
 	"syscall"
 )
 
 func setSysProcAttr(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+// processAlive reports whether the process with the given pid is still running.
+// A spawned child stays a zombie after death until reaped (the parent never
+// calls Wait), and kill(pid, 0) succeeds on zombies — so try a non-blocking
+// reap first and only fall back to signal 0 when pid is not our child.
+func processAlive(pid int) bool {
+	var ws syscall.WaitStatus
+	wpid, err := syscall.Wait4(pid, &ws, syscall.WNOHANG, nil)
+	if err == nil {
+		// wpid == pid means the child exited and has now been reaped.
+		return wpid != pid
+	}
+	if errors.Is(err, syscall.ECHILD) {
+		kerr := syscall.Kill(pid, 0)
+		return kerr == nil || errors.Is(kerr, syscall.EPERM)
+	}
+	return true
 }

--- a/cmd/sysprocattr_windows.go
+++ b/cmd/sysprocattr_windows.go
@@ -2,8 +2,21 @@
 
 package cmd
 
-import "os/exec"
+import (
+	"os"
+	"os/exec"
+)
 
 func setSysProcAttr(_ *exec.Cmd) {
 	// On Windows, child processes are independent by default.
+}
+
+// processAlive reports whether the process with the given pid is still running.
+func processAlive(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	p.Release() //nolint:errcheck
+	return true
 }


### PR DESCRIPTION
## Problem

When starting a server in the background, `waitForReady` treats any HTTP 200 on `/_/api/status` as "ready" — a JSON decode failure is even short-circuited to success (`return nil, nil //nolint:nilerr`) — and it never verifies that the spawned child is the process actually serving the port. Combined with the probe→listen TOCTOU in the CLI, this produces false success reports in three related ways (all reproduced on Linux):

1. **Concurrent startup race loses files silently.** Two `mo` invocations on the same port both pass the ~500ms probe and both spawn a server. The loser's child dies with `EADDRINUSE`, but the loser's parent receives the *winner's* status, prints `mo: serving at ... (pid <dead pid>)` with the winner's deeplinks, and exits 0. The loser's files are opened nowhere. Realistic triggers: `git ls-files '*.md' | xargs -n1 mo`, editor integrations, or a loaded machine where the existing server's probe response exceeds 500ms.
2. **A non-mo server occupying the port also yields exit 0.** If whatever is listening returns 200 to `/_/api/status`, mo reports success although the child died and the port owner is unchanged. If it returns non-200, the user gets a misleading "check log file" timeout after 10s.
3. **The child's fatal error is unrecorded.** Cobra writes RunE errors to stderr, which is `/dev/null` for background children, so `cannot listen on ...: address already in use` appears nowhere — the log only shows a secondary `shutdown error: context deadline exceeded`, caused by `watchLoop` never exiting on the listen-failure path (its exit depends on `watcher.Close()`, whose cleanup hook is registered only after a successful `net.Listen`).

## Fix

- `waitForReady` only treats a response as ready when the status decodes and carries a non-empty `version` (same validation as `probeServer`). It also takes the spawned child's PID:
  - If a mo server responds with a different PID, it returns `errServerConflict` with the winner's status. `startBackground` then falls back to POSTing the requested files/patterns/uploads to the winning server (server-side `AddFile` is idempotent for duplicate paths), and errors out if nothing could be added instead of claiming success.
  - If the child dies, it fails fast after a 1s grace period (giving a race winner a moment to start serving) instead of waiting out the full 10s. Child death is detected with a non-blocking `wait4` on Unix, because the unwaited child remains a zombie for which `kill(pid, 0)` still succeeds. On Windows, `os.FindProcess` is used best-effort; PID reuse degrades gracefully to the old full-timeout behavior.
  - The timeout message now points at the likely cause: `the port may be in use by another (non-mo) server`.
- The restore file is only removed once the child is confirmed dead — a slow-but-alive child may not have consumed it yet.
- Fatal RunE errors are `slog.Error`'d before the log file closes, so the root cause lands in `mo-<port>.log`. This is only registered when logging to a file, avoiding duplicate stderr output in `--foreground` mode.
- On listen failure, `startServer` closes the watcher so `watchLoop` exits and donegroup cleanup no longer times out after 5s.
- The race-lost fallback gates `openBrowser` on `isNewGroup || open`, matching the existing add-to-running-server path.

Known limitations (accepted): a server self-restart during the 10s polling window would be classified as a conflict (benign — the fallback POST is idempotent and the files still end up served), and Windows PID reuse can defeat the fail-fast (falls back to the previous timeout behavior).

## Behavior before / after

Concurrent race (`mo -p 17700 race-a.md` and `mo -p 17700 race-b.md` simultaneously):

```
# before (loser's output): false success, race-a.md lost, pid is a dead process
mo: serving at http://localhost:17700 (pid 23511)   # deeplink shows race-b.md

# after (loser's output): files added to the winner, nothing lost
mo: another mo server is already running at http://localhost:17700 (pid 49352); added 1 item(s) to it
```

Non-mo server on the port (`python3 -m http.server` variant returning 200):

```
# before: exit 0, "serving at ..." with a dead pid, empty log
# after: exit 1 in ~1.1s, and the log records the root cause
Error: server process exited unexpectedly; the port may be in use by another server (check log file for details) (spawned pid 48885)
# mo-17662.log: "cannot listen on localhost:17662: ... address already in use"
```

## Tests

- `TestWaitForReady_Success` / `TestWaitForReady_PIDMismatch` / `TestWaitForReady_NonMoServer` / `TestWaitForReady_ChildExited` — ready validation, conflict detection, non-mo rejection, and fail-fast on child death (zombie-based, deterministic).
- `TestProcessAlive_ZombieChild` — regression for the zombie case: `kill(pid, 0)` succeeds for an unwaited dead child, so `processAlive` must reap.
- `TestAddToRunningServer` / `TestAddToRunningServer_AllPostsFail` — fallback POSTs and the all-failed error path.
- Unix-specific tests are skipped on Windows.

## Verification

- `go build ./...`, `go test ./... -race`, `golangci-lint run` / gostyle: clean.
- Both failure scenarios reproduced on the parent commit and verified fixed end-to-end with the built binary (isolated `XDG_STATE_HOME`, ports 17xxx), including log contents and exit codes.

Reported in kiakiraki/mo#2 (with full reproduction steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)