### PR TITLE
fix(cmd): count only successful pattern POSTs when adding to a running server

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -409,8 +409,10 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 			isNewGroup := !slices.Contains(result.groups, target)
 
 			var deeplinks []deeplinkEntry
-			deeplinks = append(deeplinks, postFiles(result.client, addr, target, files)...)
-			deeplinks = append(deeplinks, postPatterns(result.client, addr, target, patterns)...)
+			fileEntries := postFiles(result.client, addr, target, files)
+			deeplinks = append(deeplinks, fileEntries...)
+			patternEntries, patternsAdded := postPatterns(result.client, addr, target, patterns)
+			deeplinks = append(deeplinks, patternEntries...)
 
 			var stdinUploadErr error
 			if stdinData != nil {
@@ -427,7 +429,10 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 				return stdinUploadErr
 			}
 
-			added := len(files) + len(patterns)
+			// Count only what was actually accepted by the running server so
+			// the "added N item(s)" line does not overstate on partial POST
+			// failures. postFiles appends exactly one entry per accepted file.
+			added := len(fileEntries) + patternsAdded
 			if stdinData != nil && stdinUploadErr == nil {
 				added++
 			}
@@ -777,8 +782,14 @@ func postFiles(client *http.Client, addr, group string, files []string) []deepli
 	return entries
 }
 
-func postPatterns(client *http.Client, addr, group string, patterns []string) []deeplinkEntry {
+// postPatterns registers each pattern with the running server. It returns the
+// deeplink entries for every file matched by the successful registrations,
+// plus the number of patterns that were actually registered (which is not
+// derivable from len(entries) because a valid pattern may legitimately match
+// zero files).
+func postPatterns(client *http.Client, addr, group string, patterns []string) ([]deeplinkEntry, int) {
 	var entries []deeplinkEntry
+	added := 0
 	for _, pat := range patterns {
 		body, err := json.Marshal(map[string]string{
 			"pattern": pat,
@@ -809,6 +820,7 @@ func postPatterns(client *http.Client, addr, group string, patterns []string) []
 			continue
 		}
 		resp.Body.Close()
+		added++
 		for _, f := range patResp.Files {
 			entries = append(entries, deeplinkEntry{
 				URL:  buildDeeplink(addr, group, f.ID),
@@ -816,7 +828,7 @@ func postPatterns(client *http.Client, addr, group string, patterns []string) []
 			})
 		}
 	}
-	return entries
+	return entries, added
 }
 
 type deeplinkEntry struct {
@@ -1527,11 +1539,10 @@ func addToRunningServer(addr string, status *statusResponse, filesByGroup map[st
 		added += len(entries)
 	}
 	for group, patterns := range patternsByGroup {
-		// A pattern may legitimately match zero files, so count patterns as
-		// added rather than by returned entries.
 		attempted += len(patterns)
-		deeplinks = append(deeplinks, postPatterns(client, addr, group, patterns)...)
-		added += len(patterns)
+		entries, patternsAdded := postPatterns(client, addr, group, patterns)
+		deeplinks = append(deeplinks, entries...)
+		added += patternsAdded
 	}
 	for _, uf := range uploadedFiles {
 		attempted++

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1017,6 +1017,55 @@ func TestAddToRunningServer_AllPostsFail(t *testing.T) {
 	}
 }
 
+// A pattern-only invocation must not report success when every pattern POST
+// fails on the winning server. Previously len(patterns) was added to the
+// counter unconditionally, defeating the "attempted > 0 && added == 0" guard.
+func TestAddToRunningServer_PatternsAllFail(t *testing.T) {
+	origNoOpen := noOpen
+	noOpen = true
+	t.Cleanup(func() { noOpen = origNoOpen })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /_/api/patterns", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "shutting down", http.StatusServiceUnavailable)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	status := &statusResponse{PID: 12345}
+	err := addToRunningServer(addr, status, nil, map[string][]string{"default": {"*.md"}}, nil)
+	if err == nil {
+		t.Fatal("expected error when every pattern POST fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to add any items") {
+		t.Fatalf("got error %q, want 'failed to add any items'", err.Error())
+	}
+}
+
+// A pattern that legitimately matches zero files must still count as added,
+// so the "added N item(s)" line does not misreport it as a failure.
+func TestAddToRunningServer_PatternWithZeroMatches(t *testing.T) {
+	origNoOpen := noOpen
+	noOpen = true
+	t.Cleanup(func() { noOpen = origNoOpen })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /_/api/patterns", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(server.AddPatternResponse{Files: nil}) //nolint:errcheck
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	status := &statusResponse{PID: 12345}
+	err := addToRunningServer(addr, status, nil, map[string][]string{"default": {"*.md"}}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestIsLoopbackBind(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Problem

The add-to-running-server path introduced by #255 (`addToRunningServer`) and the pre-existing direct add-to-running-server path both count `len(patterns)` unconditionally as "added" items:

```go
attempted += len(patterns)
deeplinks = append(deeplinks, postPatterns(...)...)
added += len(patterns)
```

`postPatterns` logs a warning and continues on any HTTP failure (marshal error, network error, non-200 response, decode error), so a pattern-only invocation whose POSTs were all rejected by the winning server is still reported as `added N item(s)` and exits 0. This defeats the `attempted > 0 && added == 0` safety net that #255 added, in the narrow but real case of "pattern-only user + winning server rejects every POST".

`len(entries)` cannot be used as a proxy for a success count because a valid pattern may legitimately match zero files, which is indistinguishable from a total POST failure from the caller's side.

Failure scenario, reproducible in principle:

1. `mo -w '*.md' -p 17700` loses a concurrent startup race.
2. Fallback `addToRunningServer` posts the pattern.
3. Winning server is under load / shutting down and returns 503.
4. mo prints `added 1 item(s) to it` and exits 0; the pattern is not registered anywhere.

## Fix

- `postPatterns` now returns `(entries []deeplinkEntry, added int)` where `added` is the number of patterns actually accepted by the server. Both callsites use it.
- The direct path also switches from `len(files)` to `len(fileEntries)` so a partial file-POST failure no longer overstates the total either (`postFiles` appends exactly one entry per accepted file, so `len(entries)` is a correct success count for files).

## Tests

- `TestAddToRunningServer_PatternsAllFail` (regression) — every pattern POST returns 503; must surface `failed to add any items`.
- `TestAddToRunningServer_PatternWithZeroMatches` — a pattern accepted by the server but matching no files must still count as added, so legitimate zero-match patterns are not reported as failures.
- Existing `TestAddToRunningServer` / `TestAddToRunningServer_AllPostsFail` continue to pass, confirming the file path is unchanged in behavior.

## Verification

- `go test ./... -race` clean
- `golangci-lint run ./...` 0 issues

Follow-up to #255.