### PR TITLE
fix(frontend): flip file context menu upward when it would overflow the viewport bottom

### DIFF
--- a/internal/frontend/src/components/FileContextMenu.tsx
+++ b/internal/frontend/src/components/FileContextMenu.tsx
@@ -1,4 +1,6 @@
+import { useLayoutEffect, useState } from "react";
 import type { FileEntry, Group } from "../hooks/useApi";
+import { shouldDropUp } from "../utils/menuPlacement";
 import { RemoveIcon } from "./RemoveIcon";
 
 const MENU_ITEM_CLASS =
@@ -29,6 +31,29 @@ export function FileContextMenu({
   onRemove,
   menuRef,
 }: FileContextMenuProps) {
+  const [dropUp, setDropUp] = useState(false);
+
+  // Measured only on open, while the menu is still at its default `top-full`
+  // position: re-running this after `dropUp` flips would make it oscillate.
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setDropUp(false);
+      return;
+    }
+    const menu = menuRef.current;
+    const anchor = menu?.parentElement;
+    if (!menu || !anchor) return;
+    const anchorRect = anchor.getBoundingClientRect();
+    setDropUp(
+      shouldDropUp({
+        anchorTop: anchorRect.top,
+        anchorBottom: anchorRect.bottom,
+        menuHeight: menu.offsetHeight,
+        viewportHeight: window.innerHeight,
+      }),
+    );
+  }, [isOpen, menuRef]);
+
   return (
     <>
       <button
@@ -46,7 +71,7 @@ export function FileContextMenu({
       {isOpen && (
         <div
           ref={menuRef}
-          className="absolute right-0 top-full z-10 bg-gh-bg border border-gh-border rounded-md shadow-lg py-1 min-w-[160px]"
+          className={`absolute right-0 ${dropUp ? "bottom-full" : "top-full"} z-10 bg-gh-bg border border-gh-border rounded-md shadow-lg py-1 min-w-[160px]`}
         >
           <button className={MENU_ITEM_CLASS} onClick={() => onOpenInNewTab(file.id)}>
             <svg className="size-4" viewBox="0 0 16 16" fill="currentColor">

--- a/internal/frontend/src/utils/menuPlacement.test.ts
+++ b/internal/frontend/src/utils/menuPlacement.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { shouldDropUp } from "./menuPlacement";
+
+describe("shouldDropUp", () => {
+  it("keeps the menu below when it fits", () => {
+    expect(
+      shouldDropUp({ anchorTop: 100, anchorBottom: 130, menuHeight: 200, viewportHeight: 800 }),
+    ).toBe(false);
+  });
+
+  it("flips up when the menu would run past the bottom edge", () => {
+    expect(
+      shouldDropUp({ anchorTop: 700, anchorBottom: 730, menuHeight: 200, viewportHeight: 800 }),
+    ).toBe(true);
+  });
+
+  it("stays below when the menu fits in neither direction", () => {
+    expect(
+      shouldDropUp({ anchorTop: 300, anchorBottom: 330, menuHeight: 500, viewportHeight: 800 }),
+    ).toBe(false);
+  });
+
+  it("keeps the menu below when it ends exactly at the bottom edge", () => {
+    expect(
+      shouldDropUp({ anchorTop: 570, anchorBottom: 600, menuHeight: 200, viewportHeight: 800 }),
+    ).toBe(false);
+  });
+});

--- a/internal/frontend/src/utils/menuPlacement.ts
+++ b/internal/frontend/src/utils/menuPlacement.ts
@@ -1,0 +1,22 @@
+interface MenuPlacementInput {
+  // Anchor row edges in viewport coordinates, as getBoundingClientRect returns them
+  anchorTop: number;
+  anchorBottom: number;
+  menuHeight: number;
+  viewportHeight: number;
+}
+
+// Flipping up is only worth it when the menu would run past the bottom edge and it
+// actually fits above. When it fits in neither direction we stay down: the sidebar
+// scrolls vertically, so a menu overflowing downward is still reachable, while one
+// flipped past the top edge is clipped for good.
+export function shouldDropUp({
+  anchorTop,
+  anchorBottom,
+  menuHeight,
+  viewportHeight,
+}: MenuPlacementInput): boolean {
+  const fitsDown = anchorBottom + menuHeight <= viewportHeight;
+  const fitsUp = anchorTop - menuHeight >= 0;
+  return !fitsDown && fitsUp;
+}


### PR DESCRIPTION
When opening the kebab menu on the bottom-most file in the sidebar,

Before — The menu opens downward and is cut off below the viewport

<img width="1274" height="653" alt="Screenshot 2026-08-01 at 13 34 48" src="https://github.com/user-attachments/assets/bea00820-8aad-4d67-98e2-c15c9b1473b7" />

After — The menu flips upward and stays fully within the viewport

<img width="1274" height="653" alt="Screenshot 2026-08-01 at 13 35 27" src="https://github.com/user-attachments/assets/92fe3f1a-b803-40e8-aaa9-06f33d9aabbb" />

