### PR TITLE
feat(frontend): reflect table of contents clicks in the URL hash

### DIFF
--- a/internal/frontend/src/App.tsx
+++ b/internal/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import {
 } from "./utils/groups";
 import { isMarkdownFile } from "./utils/filetype";
 import { formatFileLabel } from "./utils/fileLabel";
+import { jumpToHeading } from "./utils/jumpToHeading";
 
 const VIEWMODE_STORAGE_KEY = "mo-sidebar-viewmode";
 const WIDTH_STORAGE_KEY = "mo-layout-width";
@@ -466,9 +467,7 @@ export function App() {
   );
 
   const handleHeadingClick = useCallback((id: string) => {
-    const el = document.getElementById(id);
-    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    el?.scrollIntoView({ behavior: reduced ? "auto" : "smooth", block: "start" });
+    jumpToHeading(id);
   }, []);
 
   const handleZoom = useCallback((content: ZoomContent) => {

--- a/internal/frontend/src/hooks/useScrollRestoration.test.ts
+++ b/internal/frontend/src/hooks/useScrollRestoration.test.ts
@@ -39,11 +39,13 @@ function addHeading(id: string, topOffset: number) {
 
 beforeEach(() => {
   sessionStorage.clear();
+  window.history.replaceState(null, "", "/");
 });
 
 afterEach(() => {
   document.body.innerHTML = "";
   sessionStorage.clear();
+  window.history.replaceState(null, "", "/");
 });
 
 describe("useScrollRestoration", () => {
@@ -264,6 +266,102 @@ describe("useScrollRestoration", () => {
         result.current.onContentRendered();
       });
       expect(container.scrollTop).toBe(0);
+    });
+  });
+
+  describe("URL hash deep link", () => {
+    it("scrolls to the heading named in the URL hash on first render", () => {
+      window.history.replaceState(null, "", "/#section-3");
+      const container = makeContainer(0);
+      addHeading("section-3", 120);
+
+      const { result } = renderHook(
+        ({ sc, headingId, fileId }) => useScrollRestoration(sc, headingId, fileId),
+        {
+          initialProps: {
+            sc: container as HTMLElement | null,
+            headingId: null as string | null,
+            fileId: "file1" as string | null,
+          },
+        },
+      );
+
+      act(() => {
+        result.current.onContentRendered();
+      });
+
+      // Heading sits 120px below the container top, so it lands at the top.
+      expect(container.scrollTop).toBe(120);
+    });
+
+    it("takes priority over a saved scroll position from reload", () => {
+      window.history.replaceState(null, "", "/#section-3");
+      const container = makeContainer(0);
+      addHeading("section-3", 90);
+
+      sessionStorage.setItem(
+        SCROLL_SESSION_KEY,
+        JSON.stringify({
+          headingId: null,
+          relativeOffset: 0,
+          rawScrollTop: 750,
+          fileId: "file1",
+          url: "/",
+        }),
+      );
+
+      const { result } = renderHook(
+        ({ sc, headingId, fileId }) => useScrollRestoration(sc, headingId, fileId),
+        {
+          initialProps: {
+            sc: container as HTMLElement | null,
+            headingId: null as string | null,
+            fileId: "file1" as string | null,
+          },
+        },
+      );
+
+      act(() => {
+        result.current.onContentRendered();
+      });
+
+      expect(container.scrollTop).toBe(90);
+      expect(sessionStorage.getItem(SCROLL_SESSION_KEY)).toBeNull();
+    });
+
+    it("only applies the hash once, then falls through to restore", () => {
+      window.history.replaceState(null, "", "/#missing-heading");
+      const container = makeContainer(0);
+
+      sessionStorage.setItem(
+        SCROLL_SESSION_KEY,
+        JSON.stringify({
+          headingId: null,
+          relativeOffset: 0,
+          rawScrollTop: 500,
+          fileId: "file1",
+          url: "/",
+        }),
+      );
+
+      const { result } = renderHook(
+        ({ sc, headingId, fileId }) => useScrollRestoration(sc, headingId, fileId),
+        {
+          initialProps: {
+            sc: container as HTMLElement | null,
+            headingId: null as string | null,
+            fileId: "file1" as string | null,
+          },
+        },
+      );
+
+      // Hash target is absent, so this render consumes the hash without scrolling
+      // and still restores the saved position.
+      act(() => {
+        result.current.onContentRendered();
+      });
+
+      expect(container.scrollTop).toBe(500);
     });
   });
 

--- a/internal/frontend/src/hooks/useScrollRestoration.ts
+++ b/internal/frontend/src/hooks/useScrollRestoration.ts
@@ -10,6 +10,16 @@ interface ScrollContext {
   url: string;
 }
 
+function initialHashId(): string | null {
+  const raw = window.location.hash.slice(1);
+  if (!raw) return null;
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
 export function useScrollRestoration(
   scrollContainer: HTMLElement | null,
   activeHeadingId: string | null,
@@ -18,6 +28,9 @@ export function useScrollRestoration(
   const savedContextRef = useRef<ScrollContext | null>(null);
   const pendingRestoreRef = useRef(false);
   const sessionRestoredRef = useRef(false);
+  // A heading id from the initial URL hash (e.g. a shared table-of-contents deep
+  // link). Applied once, after the first content render, then cleared.
+  const hashScrollRef = useRef<string | null>(initialHashId());
 
   // Single ref object for stable access in beforeunload and captureScrollPosition
   const latestRef = useRef({ scrollContainer, activeHeadingId, activeFileId });
@@ -80,6 +93,29 @@ export function useScrollRestoration(
 
   const onContentRendered = useCallback(() => {
     const fileId = latestRef.current.activeFileId;
+
+    // A URL hash points at a specific heading, so it wins over a restored scroll
+    // position on load. Consumed once so later renders fall through to restore.
+    const hashId = hashScrollRef.current;
+    if (hashId) {
+      hashScrollRef.current = null;
+      const sc = latestRef.current.scrollContainer;
+      const headingEl = document.getElementById(hashId);
+      if (sc && headingEl) {
+        const offset = headingEl.getBoundingClientRect().top - sc.getBoundingClientRect().top;
+        sc.scrollTop += offset;
+        // Drop any saved position so a later render does not undo the deep link.
+        savedContextRef.current = null;
+        pendingRestoreRef.current = false;
+        sessionRestoredRef.current = true;
+        try {
+          sessionStorage.removeItem(SCROLL_SESSION_KEY);
+        } catch {
+          // ignore
+        }
+        return;
+      }
+    }
 
     // Path A: React re-render (ref-based)
     if (pendingRestoreRef.current && savedContextRef.current) {

--- a/internal/frontend/src/utils/jumpToHeading.test.ts
+++ b/internal/frontend/src/utils/jumpToHeading.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { jumpToHeading } from "./jumpToHeading";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  window.history.replaceState(null, "", "/");
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  window.history.replaceState(null, "", "/");
+});
+
+describe("jumpToHeading", () => {
+  it("scrolls to the heading and updates the URL hash", () => {
+    const heading = document.createElement("h2");
+    heading.id = "getting-started";
+    const scrollIntoView = vi.fn();
+    heading.scrollIntoView = scrollIntoView;
+    document.body.appendChild(heading);
+
+    const result = jumpToHeading("getting-started");
+
+    expect(result).toBe(true);
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+    expect(window.location.hash).toBe("#getting-started");
+  });
+
+  it("does nothing and returns false when the heading is missing", () => {
+    const result = jumpToHeading("missing");
+
+    expect(result).toBe(false);
+    expect(window.location.hash).toBe("");
+  });
+});

--- a/internal/frontend/src/utils/jumpToHeading.ts
+++ b/internal/frontend/src/utils/jumpToHeading.ts
@@ -1,0 +1,11 @@
+// Scroll to a heading by id and reflect it in the URL hash so the location can
+// be copied as a deep link, matching how in-document anchor links behave.
+export function jumpToHeading(id: string): boolean {
+  const el = document.getElementById(id);
+  if (!el) return false;
+
+  const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  el.scrollIntoView({ behavior: reduced ? "auto" : "smooth", block: "start" });
+  window.history.pushState(null, "", `#${id}`);
+  return true;
+}


### PR DESCRIPTION
Fixes #217.

Clicking a heading in the table of contents now updates the URL hash, the same way an in-document anchor link already does, so you can copy the current location and share it as a deep link. Opening or reloading a URL that has a heading hash scrolls to that heading once the markdown has rendered.

I pulled the scroll-and-update-hash bit into a small `jumpToHeading` helper, and put the on-load handling in `useScrollRestoration` so a deep link takes priority over the restored scroll position. Existing smooth scrolling and modified-click behavior are unchanged. Tests cover the new helper and the hash-on-load paths.