### PR TITLE
fix: render single-line $$...$$ as block math

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ internal/static/dist/**/*
 internal/frontend/CREDITS_FRONTEND
 coverage.out
 mo
+mo.exe

--- a/internal/frontend/src/components/MarkdownViewer.tsx
+++ b/internal/frontend/src/components/MarkdownViewer.tsx
@@ -21,6 +21,7 @@ import { resolveLink, resolveImageSrc, extractLanguage } from "../utils/resolve"
 import { buildRelativeOpenUrl } from "../utils/groups";
 import { parseFrontmatter } from "../utils/frontmatter";
 import { stripMdxSyntax } from "../utils/mdx";
+import { normalizeDisplayMath } from "../utils/displayMath";
 import { isMarkdownFile, detectLanguage } from "../utils/filetype";
 import { formatFileLabel } from "../utils/fileLabel";
 import type { ZoomContent } from "./ZoomModal";
@@ -750,7 +751,9 @@ export function MarkdownViewer({
       return <RawView content={content} />;
     }
     const base = parsed ? parsed.content : content;
-    const md = fileName.toLowerCase().endsWith(".mdx") ? stripMdxSyntax(base) : base;
+    const md = fileName.toLowerCase().endsWith(".mdx")
+      ? normalizeDisplayMath(stripMdxSyntax(base))
+      : normalizeDisplayMath(base);
     return (
       <>
         {parsed && <FrontmatterBlock yaml={parsed.yaml} />}

--- a/internal/frontend/src/utils/displayMath.test.ts
+++ b/internal/frontend/src/utils/displayMath.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { normalizeDisplayMath } from "./displayMath";
+
+describe("normalizeDisplayMath", () => {
+  it("converts single-line $$...$$ display math to block form", () => {
+    const input = "$$F(x, y) = \\int_0^{x-y} (x-y-t) f(t)\\, dt$$";
+    expect(normalizeDisplayMath(input)).toBe(
+      "$$\nF(x, y) = \\int_0^{x-y} (x-y-t) f(t)\\, dt\n$$",
+    );
+  });
+
+  it("converts $$...$$ embedded in a paragraph to block form", () => {
+    const input = "around text $$y=x$$ around text";
+    expect(normalizeDisplayMath(input)).toBe("around text \n$$\ny=x\n$$\n around text");
+  });
+
+  it("converts multiple single-line $$...$$ expressions", () => {
+    const input = "$$a$$ and $$b$$";
+    expect(normalizeDisplayMath(input)).toBe("$$\na\n$$\n and \n$$\nb\n$$");
+  });
+
+  it("leaves an unpaired $$ untouched", () => {
+    const input = "echo $$ > /tmp/pid";
+    expect(normalizeDisplayMath(input)).toBe(input);
+  });
+
+  it("passes fenced code blocks through unchanged", () => {
+    const input = "```bash\necho $$ > /tmp/pid; kill $$\n```";
+    expect(normalizeDisplayMath(input)).toBe(input);
+  });
+
+  it("passes tilde-fenced code blocks through unchanged", () => {
+    const input = "~~~\n$$x$$\n~~~";
+    expect(normalizeDisplayMath(input)).toBe(input);
+  });
+
+  it("passes everything after an unclosed fence through unchanged", () => {
+    const input = "```\n$$a$$\ntext $$b$$\n";
+    expect(normalizeDisplayMath(input)).toBe(input);
+  });
+
+  it("converts math again after a fence closes", () => {
+    const input = "```\n$$in code$$\n```\n$$F(x)$$\n";
+    expect(normalizeDisplayMath(input)).toBe("```\n$$in code$$\n```\n$$\nF(x)\n$$\n");
+  });
+
+  it("passes multi-line block math through unchanged", () => {
+    const input = "$$\n\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}\n$$";
+    expect(normalizeDisplayMath(input)).toBe(input);
+  });
+
+  it("passes text without display math through unchanged", () => {
+    const input = "Just plain text with $math$ already.";
+    expect(normalizeDisplayMath(input)).toBe(input);
+  });
+});

--- a/internal/frontend/src/utils/displayMath.ts
+++ b/internal/frontend/src/utils/displayMath.ts
@@ -1,0 +1,57 @@
+/**
+ * Expand single-line `$$...$$` display math into the multi-line block form
+ * (`$$\n...\n$$`) that remark-math treats as flow (block) math.
+ *
+ * micromark-extension-math parses `$$x$$` on a single line as inline math,
+ * while Pandoc, MathJax, and GitHub render it as display math. Normalizing
+ * here keeps such documents rendering as block math in mo.
+ *
+ * Fenced code blocks are tracked line-by-line and passed through unchanged,
+ * the same approach as stripMdxSyntax in ./mdx.
+ */
+export function normalizeDisplayMath(md: string): string {
+  const lines = md.split("\n");
+  const result: string[] = [];
+  let fenceChar = "";
+  let fenceLen = 0;
+
+  for (const line of lines) {
+    const fenceMatch = /^(`{3,}|~{3,})/.exec(line);
+    if (fenceMatch) {
+      const char = fenceMatch[1][0];
+      const len = fenceMatch[1].length;
+      if (fenceChar) {
+        if (char === fenceChar && len >= fenceLen) {
+          fenceChar = "";
+          fenceLen = 0;
+        }
+      } else {
+        fenceChar = char;
+        fenceLen = len;
+      }
+      result.push(line);
+      continue;
+    }
+
+    if (fenceChar) {
+      result.push(line);
+      continue;
+    }
+
+    result.push(expandLineDisplayMath(line));
+  }
+
+  return result.join("\n");
+}
+
+// Expand each `$$...$$` pair on the line to the multi-line block form. The
+// regex cannot cross line boundaries, so an unpaired `$$` is left as-is.
+function expandLineDisplayMath(line: string): string {
+  return line.replace(/\$\$([^\n]*?)\$\$/g, (match, inner: string, offset: number) => {
+    const before = line[offset - 1];
+    const after = line[offset + match.length];
+    const prefix = before != null ? "\n" : "";
+    const suffix = after != null ? "\n" : "";
+    return `${prefix}$$\n${inner}\n$$${suffix}`;
+  });
+}

--- a/testdata/math.md
+++ b/testdata/math.md
@@ -24,6 +24,20 @@ $$
 \sum_{i=1}^n i = \frac{n(n+1)}{2}
 $$
 
+$$F(x, y) = \int_0^{x-y} (x-y-t) f(t)\, dt$$
+
+around text
+$$y=x$$
+around text
+
+around text $$y=x$$ around text
+
+`$$...$$` inside fenced code blocks must stay untouched:
+
+```bash
+echo $$ > /tmp/pid; kill $$
+```
+
 ## Matrix
 
 A 2x2 matrix:


### PR DESCRIPTION
## What

Render single-line `$$...$$` — whether on its own line or embedded in a paragraph — as block display math instead of inline math.

## Why

micromark-extension-math parses `$$x$$` on a single line as inline math, while Pandoc, MathJax, and GitHub render single-line `$$...$$` as display math. Documents written for those renderers (including AI-generated content) therefore display surprisingly in mo.

## How

Before rendering, single-line `$$...$$` is expanded into the multi-line block form that remark-math already treats as flow math. Fenced code blocks are tracked line-by-line and passed through unchanged (same pattern as `stripMdxSyntax`), so the contents of code blocks are never rewritten.

A remark/mdast-level plugin cannot handle this case: once micromark parses `$$x$$` and `$x$`, both become identical `inlineMath` nodes, so the delimiter information is already lost at that layer.

## Note

Support for MathJax-style `\(...\)` / `\[...\]` delimiters was removed from this PR per review feedback.

Most of the code changes in this PR were made by Kimi Code.
