### PR TITLE
ci: run tests on windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
@@ -59,7 +59,17 @@ jobs:
           config-file: .gostyle.yml
 
       - name: Run tests
+        if: runner.os != 'Windows'
         run: make ci
+
+      - name: Run frontend tests (Windows)
+        if: runner.os == 'Windows'
+        working-directory: internal/frontend
+        run: pnpm install && pnpm run test:coverage
+
+      - name: Run Go tests (Windows)
+        if: runner.os == 'Windows'
+        run: go test ./... -coverprofile=coverage.out -covermode=count -count=1
 
       - name: Run octocov
         if: runner.os == 'Linux'

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -130,7 +131,7 @@ func TestPath(t *testing.T) {
 		t.Fatalf("Path returned error: %v", err)
 	}
 
-	want := dir + "/mo/backup/mo-6275.json"
+	want := filepath.Join(dir, "mo", "backup", "mo-6275.json")
 	if p != want {
 		t.Fatalf("got %s, want %s", p, want)
 	}


### PR DESCRIPTION
## Problem

`mo` ships for Windows, but the test matrix is `[ubuntu-latest, macos-latest]`.
Path-separator bugs are invisible to both, because those two agree on `/` and only
Windows disagrees.

`TestPath` in `internal/backup` already fails on `main` for that reason:

```
backup_test.go:135: got  C:\Users\...\001\mo\backup\mo-6275.json
                    want C:\Users\...\001/mo/backup/mo-6275.json
```

It concatenates the expected value with `/` while `Path` uses `filepath.Join`. I found
it while checking #272, which introduces a second Windows-only failure of the same
shape.

## Fix

Add `windows-latest` to the matrix.

`make ci` cannot run there: the image ships no `make` on `PATH` (MSYS2 is present but
not on `PATH`, and the software inventory lists no GNU Make). The Windows job runs the
`ci` target's two test commands as their own steps instead. Its other prerequisites
are already met — `generate` has its own step above, and `depsdev` only installs tools
the Linux-guarded steps use.

Nothing else needed touching: oxlint, oxfmt, golangci-lint, gostyle and octocov are
already guarded by `runner.os == 'Linux'`.

## Tests

No new tests. `TestPath` now builds its expected value with `filepath.Join`, matching
the implementation, so it holds on every platform.

## Verification

Green on all three runners on my fork, including the new one:
ShortArrow/mo#1 (run 33845484241).

On `Test (windows-latest)` the frontend build ran, `make ci` was skipped, and the two
Windows steps passed under the runner's default shell:

```
Generate frontend assets        success  34s
Run tests                       skipped
Run frontend tests (Windows)    success  31s
Run Go tests (Windows)          success  34s
```

`ubuntu-latest` and `macos-latest` still take the `make ci` step and skip the two
Windows ones.
