### PR TITLE
fix(server): correct watch and pattern bookkeeping around symlink aliases

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -962,12 +962,18 @@ func (s *State) walkDirsForPattern(gp *GlobPattern, fn func(string)) {
 	}
 
 	unresolved, err := walkSymlinkTree(gp.BaseDir, fn, nil)
-	// Directories that could not be classified never reached fn, so hand them
-	// over here. Without this, unwatch cannot decrement the refcount of a
-	// directory that was deleted after the watch was set up, and the watch on
-	// its canonical target is never released.
+	// Entries that could not be classified never reached fn, so hand over the
+	// ones already tracked as watched directories. Without this, unwatch cannot
+	// decrement the refcount of a directory that stopped resolving after its
+	// watch was set up, and the watch on its canonical target is never released.
+	// The rest are skipped because unresolved also covers non-directory entries
+	// such as dangling file symlinks, which have no refcount to release and
+	// would only produce a failed watch and a misleading warning on the add
+	// path.
 	for _, path := range unresolved {
-		fn(path)
+		if s.isWatchedDir(path) {
+			fn(path)
+		}
 	}
 	if err != nil {
 		slog.Warn("failed to walk directories for pattern", "pattern", gp.Pattern, "base", gp.BaseDir, "error", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1008,7 +1008,7 @@ func (s *State) removeFileWatch(absPath string) {
 	delete(s.fileWatchTargets, target)
 	if s.watcher != nil {
 		if err := s.watcher.Remove(target); err != nil {
-			slog.Warn("failed to unwatch file", "path", absPath, "error", err)
+			slog.Warn("failed to unwatch file", "path", absPath, "target", target, "error", err)
 		}
 	}
 }
@@ -1040,7 +1040,7 @@ func (s *State) removeDirWatch(dir string) {
 	delete(s.watchTargets, target)
 	if s.watcher != nil {
 		if err := s.watcher.Remove(target); err != nil {
-			slog.Warn("failed to remove directory watch", "dir", dir, "error", err)
+			slog.Warn("failed to remove directory watch", "dir", dir, "target", target, "error", err)
 		}
 	}
 }
@@ -1373,7 +1373,7 @@ func (s *State) addFileWatch(absPath, canonical string) {
 		if err := s.watcher.Add(target, watchOps); err != nil && !errors.Is(err, fswatcher.ErrAlreadyAdded) {
 			delete(s.watchedFiles, absPath)
 			delete(s.fileWatchTargets, target)
-			slog.Warn("failed to watch file", "path", absPath, "error", err)
+			slog.Warn("failed to watch file", "path", absPath, "target", target, "error", err)
 			return
 		}
 	}
@@ -1409,7 +1409,7 @@ func (s *State) addDirWatch(dir string) {
 		if err := s.watcher.Add(target, watchOps); err != nil && !errors.Is(err, fswatcher.ErrAlreadyAdded) {
 			delete(s.watchedDirs, dir)
 			delete(s.watchTargets, target)
-			slog.Warn("failed to watch directory", "path", dir, "error", err)
+			slog.Warn("failed to watch directory", "path", dir, "target", target, "error", err)
 			return
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -219,6 +219,12 @@ type State struct {
 	// entry can be removed without re-running EvalSymlinks (which would
 	// fail once the underlying file or directory is gone).
 	aliasReverse map[string]string
+	// watchedFiles and fileWatchTargets mirror watchedDirs and watchTargets on
+	// the file side. One physical file reachable through several symlink
+	// aliases has one entry per alias path but only one watch, so the logical
+	// paths and the physical watch target have to be counted separately.
+	watchedFiles     map[string]int
+	fileWatchTargets map[string]int
 
 	fileChangeDebounce time.Duration
 	fileChangeTimers   map[string]*time.Timer
@@ -246,6 +252,8 @@ func NewState(ctx context.Context) *State {
 		watchTargets:       make(map[string]int),
 		pathAliases:        make(map[string]map[string]struct{}),
 		aliasReverse:       make(map[string]string),
+		watchedFiles:       make(map[string]int),
+		fileWatchTargets:   make(map[string]int),
 		fileChangeDebounce: defaultFileChangeDebounce,
 		fileChangeTimers:   make(map[string]*time.Timer),
 	}
@@ -339,15 +347,7 @@ func (s *State) AddFile(absPath, groupName string) (*FileEntry, error) {
 	g.Files = append(g.Files, entry)
 
 	if s.watcher != nil {
-		if err := s.watcher.Add(absPath, watchOps); err != nil {
-			if errors.Is(err, fswatcher.ErrAlreadyAdded) {
-				s.registerPathAlias(absPath, canonical)
-			} else {
-				slog.Warn("failed to watch file", "path", absPath, "error", err)
-			}
-		} else {
-			s.registerPathAlias(absPath, canonical)
-		}
+		s.addFileWatch(absPath, canonical)
 	}
 
 	slog.Info("file added", "path", absPath, "group", groupName, "id", entry.ID) //nolint:gosec // G706: structured logging fields, no injection risk
@@ -540,12 +540,12 @@ func (s *State) RemoveFilesByPath(absPath string) bool {
 	}
 
 	s.mu.Lock()
-	removed := false
+	removedCount := 0
 	for name, g := range s.groups {
 		filtered := g.Files[:0]
 		for _, f := range g.Files {
 			if f.Path == absPath {
-				removed = true
+				removedCount++
 				slog.Info("file removed", "path", f.Path, "id", f.ID, "group", name) //nolint:gosec // G706: structured logging fields, no injection risk
 				continue
 			}
@@ -561,14 +561,14 @@ func (s *State) RemoveFilesByPath(absPath string) bool {
 			delete(s.groups, name)
 		}
 	}
-	if removed && s.watcher != nil {
-		if err := s.watcher.Remove(absPath); err != nil {
-			slog.Warn("failed to unwatch file", "path", absPath, "error", err)
+	if s.watcher != nil {
+		for range removedCount {
+			s.removeFileWatch(absPath)
 		}
-		s.unregisterPathAlias(absPath)
 	}
 	s.mu.Unlock()
 
+	removed := removedCount > 0
 	if removed {
 		s.sendEvent(sseEvent{Name: eventUpdate, Data: "{}"})
 	}
@@ -600,26 +600,8 @@ func (s *State) RemoveFile(id, groupName string) bool {
 
 	slog.Info("file removed", "path", removedPath, "id", id) //nolint:gosec // G706: removedPath is from internal state, not direct user input
 
-	// Remove watcher only if no other file references the same path
 	if s.watcher != nil && removedPath != "" {
-		stillReferenced := false
-		for _, g := range s.groups {
-			for _, f := range g.Files {
-				if f.Path == removedPath {
-					stillReferenced = true
-					break
-				}
-			}
-			if stillReferenced {
-				break
-			}
-		}
-		if !stillReferenced {
-			if err := s.watcher.Remove(removedPath); err != nil {
-				slog.Warn("failed to unwatch file", "path", removedPath, "error", err)
-			}
-			s.unregisterPathAlias(removedPath)
-		}
+		s.removeFileWatch(removedPath)
 	}
 
 	s.sendEvent(sseEvent{Name: eventUpdate, Data: "{}"})
@@ -694,12 +676,12 @@ func (s *State) AddPattern(absPattern, groupName string) ([]*FileEntry, error) {
 		return nil, fmt.Errorf("base path %q is not a directory", base)
 	}
 
-	gp, added := func() (*GlobPattern, bool) {
+	gp, createdGroup, added := func() (*GlobPattern, bool, bool) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		for _, p := range s.patterns {
 			if p.Pattern == absPattern && p.Group == groupName {
-				return nil, false
+				return nil, false, false
 			}
 		}
 		gp := &GlobPattern{
@@ -710,10 +692,12 @@ func (s *State) AddPattern(absPattern, groupName string) ([]*FileEntry, error) {
 		}
 		s.patterns = append(s.patterns, gp)
 		// Ensure the group exists even if no files match yet.
+		createdGroup := false
 		if _, ok := s.groups[groupName]; !ok {
 			s.groups[groupName] = &Group{Name: groupName}
+			createdGroup = true
 		}
-		return gp, true
+		return gp, createdGroup, true
 	}()
 	if !added {
 		return nil, nil
@@ -723,7 +707,7 @@ func (s *State) AddPattern(absPattern, groupName string) ([]*FileEntry, error) {
 	var matches []string
 	if gp.IsRecursive() {
 		var matchErr error
-		err = walkSymlinkTree(base, nil, func(path string) {
+		_, err = walkSymlinkTree(base, nil, func(path string) {
 			if matchErr != nil {
 				return
 			}
@@ -733,6 +717,11 @@ func (s *State) AddPattern(absPattern, groupName string) ([]*FileEntry, error) {
 				return
 			}
 			if matched {
+				// Alias paths are kept as distinct matches rather than collapsed
+				// onto their canonical form. FileID is derived from the path, so
+				// collapsing would make the surviving ID depend on ReadDir order
+				// and break deep links and session restore, and preferring the
+				// canonical form would move an entry outside the watched tree.
 				rel, err := filepath.Rel(base, path)
 				if err == nil {
 					matches = append(matches, rel)
@@ -746,6 +735,7 @@ func (s *State) AddPattern(absPattern, groupName string) ([]*FileEntry, error) {
 		matches, err = doublestar.Glob(os.DirFS(base), relPat, doublestar.WithFilesOnly())
 	}
 	if err != nil {
+		s.rollbackPattern(gp, createdGroup)
 		return nil, fmt.Errorf("glob expansion failed: %w", err)
 	}
 	collate.New(language.Und, collate.Numeric).SortStrings(matches)
@@ -971,19 +961,49 @@ func (s *State) walkDirsForPattern(gp *GlobPattern, fn func(string)) {
 		return
 	}
 
-	visitedBase := false
-	err := walkSymlinkTree(gp.BaseDir, func(path string) {
-		if path == gp.BaseDir {
-			visitedBase = true
-		}
+	unresolved, err := walkSymlinkTree(gp.BaseDir, fn, nil)
+	// Directories that could not be classified never reached fn, so hand them
+	// over here. Without this, unwatch cannot decrement the refcount of a
+	// directory that was deleted after the watch was set up, and the watch on
+	// its canonical target is never released.
+	for _, path := range unresolved {
 		fn(path)
-	}, nil)
+	}
 	if err != nil {
-		// BaseDir may have been deleted; still clean up the base directory entry.
-		if !visitedBase {
-			fn(gp.BaseDir)
-		}
 		slog.Warn("failed to walk directories for pattern", "pattern", gp.Pattern, "base", gp.BaseDir, "error", err)
+	}
+}
+
+// removeFileWatch releases one logical reference to a file path and drops the
+// physical watch only once no alias of the same target remains.
+// Caller must hold s.mu for write.
+func (s *State) removeFileWatch(absPath string) {
+	count, ok := s.watchedFiles[absPath]
+	if !ok {
+		return
+	}
+	if count > 1 {
+		s.watchedFiles[absPath] = count - 1
+		return
+	}
+
+	delete(s.watchedFiles, absPath)
+	target := absPath
+	if canonical, ok := s.aliasReverse[absPath]; ok {
+		target = canonical
+	}
+	s.unregisterPathAlias(absPath)
+
+	targetCount := s.fileWatchTargets[target]
+	if targetCount > 1 {
+		s.fileWatchTargets[target] = targetCount - 1
+		return
+	}
+	delete(s.fileWatchTargets, target)
+	if s.watcher != nil {
+		if err := s.watcher.Remove(target); err != nil {
+			slog.Warn("failed to unwatch file", "path", absPath, "error", err)
+		}
 	}
 }
 
@@ -1295,6 +1315,65 @@ func (s *State) watchDirsForPattern(gp *GlobPattern) {
 	s.walkDirsForPattern(gp, s.addDirWatch)
 }
 
+// rollbackPattern undoes what AddPattern registers before its initial
+// expansion. Without it a failed expansion leaves a pattern that nothing
+// watches: it is reported by the status API and persisted to the backup, and a
+// later RemovePattern walks the tree decrementing refcounts it never
+// incremented, which can release a watch another pattern still needs.
+func (s *State) rollbackPattern(gp *GlobPattern, createdGroup bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, p := range s.patterns {
+		if p == gp {
+			s.patterns = append(s.patterns[:i], s.patterns[i+1:]...)
+			break
+		}
+	}
+	if !createdGroup {
+		return
+	}
+	if g, ok := s.groups[gp.Group]; ok && len(g.Files) == 0 && !s.groupHasPatterns(gp.Group) {
+		delete(s.groups, gp.Group)
+	}
+}
+
+// addFileWatch registers a watch for a file path. Logical paths and the
+// physical watch target are counted separately so that several symlink
+// aliases of one file share a single watch, and removing one alias does not
+// tear down the watch the remaining aliases still rely on.
+// Caller must hold s.mu for write.
+func (s *State) addFileWatch(absPath, canonical string) {
+	target := absPath
+	if canonical != "" {
+		target = canonical
+	}
+	if s.watchedFiles == nil {
+		s.watchedFiles = make(map[string]int)
+	}
+	if s.fileWatchTargets == nil {
+		s.fileWatchTargets = make(map[string]int)
+	}
+	s.watchedFiles[absPath]++
+	if s.watchedFiles[absPath] > 1 {
+		return
+	}
+
+	s.fileWatchTargets[target]++
+	if s.fileWatchTargets[target] > 1 {
+		s.registerPathAlias(absPath, canonical)
+		return
+	}
+	if s.watcher != nil {
+		if err := s.watcher.Add(target, watchOps); err != nil && !errors.Is(err, fswatcher.ErrAlreadyAdded) {
+			delete(s.watchedFiles, absPath)
+			delete(s.fileWatchTargets, target)
+			slog.Warn("failed to watch file", "path", absPath, "error", err)
+			return
+		}
+	}
+	s.registerPathAlias(absPath, canonical)
+}
+
 func (s *State) addDirWatch(dir string) {
 	canonical := resolvePathAlias(dir)
 	target := dir
@@ -1356,7 +1435,7 @@ func (s *State) handleCreateForGlobs(path string) {
 		if watchCount == 0 {
 			return
 		}
-		if err := walkSymlinkTree(path, func(dir string) {
+		if _, err := walkSymlinkTree(path, func(dir string) {
 			for range watchCount {
 				s.addDirWatch(dir)
 			}
@@ -1376,11 +1455,18 @@ func pathWithinBase(path, base string) bool {
 	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
-func walkSymlinkTree(root string, visitDir, visitFile func(string)) error {
+// walkSymlinkTree walks root, descending through directory symlinks, handing
+// every directory to visitDir and every other entry to visitFile. Paths that
+// could not be classified are returned separately instead of being dropped,
+// because a caller keeping per-directory state still has to reach a directory
+// that vanished between watch setup and teardown.
+func walkSymlinkTree(root string, visitDir, visitFile func(string)) ([]string, error) {
+	var unresolved []string
 	var walk func(string, map[string]struct{}) error
 	walk = func(path string, ancestors map[string]struct{}) error {
 		info, err := os.Stat(path)
 		if err != nil {
+			unresolved = append(unresolved, path)
 			return err
 		}
 		if !info.IsDir() {
@@ -1392,6 +1478,7 @@ func walkSymlinkTree(root string, visitDir, visitFile func(string)) error {
 
 		canonical, err := filepath.EvalSymlinks(path)
 		if err != nil {
+			unresolved = append(unresolved, path)
 			return err
 		}
 		if _, ok := ancestors[canonical]; ok {
@@ -1408,6 +1495,8 @@ func walkSymlinkTree(root string, visitDir, visitFile func(string)) error {
 		}
 		entries, err := os.ReadDir(path)
 		if err != nil {
+			// path already went to visitDir, so it must not also be reported as
+			// unresolved; teardown would otherwise decrement it twice.
 			return err
 		}
 		for _, entry := range entries {
@@ -1419,7 +1508,8 @@ func walkSymlinkTree(root string, visitDir, visitFile func(string)) error {
 		return nil
 	}
 
-	return walk(root, nil)
+	err := walk(root, nil)
+	return unresolved, err
 }
 
 func (s *State) matchAndAddFile(path string, patterns []*GlobPattern) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -13,6 +13,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -40,6 +42,8 @@ func newTestState(t *testing.T) *State {
 		watchTargets:       make(map[string]int),
 		pathAliases:        make(map[string]map[string]struct{}),
 		aliasReverse:       make(map[string]string),
+		watchedFiles:       make(map[string]int),
+		fileWatchTargets:   make(map[string]int),
 		fileChangeDebounce: defaultFileChangeDebounce,
 		fileChangeTimers:   make(map[string]*time.Timer),
 	}
@@ -2686,5 +2690,283 @@ func TestAddFile_PathStaysOSNative(t *testing.T) {
 	}
 	if dup.ID != entry.ID {
 		t.Errorf("duplicate add returned different entry ID %q, want %q", dup.ID, entry.ID)
+	}
+}
+
+// walkSymlinkTree must report entries it could not classify instead of
+// dropping them, so that watch teardown can still reach them.
+func TestWalkSymlinkTree_ReportsUnresolvedEntries(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "note.md"), []byte("# Note"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dangling := filepath.Join(dir, "dangling")
+	if err := os.Symlink(filepath.Join(dir, "missing"), dangling); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	var dirs, files []string
+	unresolved, err := walkSymlinkTree(dir, func(p string) {
+		dirs = append(dirs, p)
+	}, func(p string) {
+		files = append(files, p)
+	})
+	if err != nil {
+		t.Fatalf("walkSymlinkTree returned error: %v", err)
+	}
+	if !slices.Contains(unresolved, dangling) {
+		t.Errorf("unresolved = %q, want it to contain %q", unresolved, dangling)
+	}
+	if slices.Contains(dirs, dangling) || slices.Contains(files, dangling) {
+		t.Errorf("dangling symlink must not be visited: dirs=%q files=%q", dirs, files)
+	}
+	if !slices.Contains(files, filepath.Join(dir, "note.md")) {
+		t.Errorf("files = %q, want it to contain note.md", files)
+	}
+}
+
+// A directory that stops resolving after the watch was set up must still have
+// its reference count released when the pattern is removed.
+func TestRemovePattern_ReleasesWatchForUnresolvedDir(t *testing.T) {
+	ctx, cancel := donegroup.WithCancel(context.Background())
+	defer cancel()
+
+	s := NewState(ctx)
+
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "real")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(dir, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	pattern := filepath.Join(dir, "**", "*.md")
+	if _, err := s.AddPattern(pattern, DefaultGroup); err != nil {
+		t.Fatalf("AddPattern returned error: %v", err)
+	}
+
+	s.mu.RLock()
+	_, watched := s.watchedDirs[linkDir]
+	s.mu.RUnlock()
+	if !watched {
+		t.Fatalf("watchedDirs does not contain %q after AddPattern", linkDir)
+	}
+
+	// The symlink now dangles, so the walk can no longer classify it.
+	if err := os.RemoveAll(realDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if !s.RemovePattern(pattern, DefaultGroup) {
+		t.Fatal("RemovePattern returned false")
+	}
+
+	s.mu.RLock()
+	count, stillWatched := s.watchedDirs[linkDir]
+	s.mu.RUnlock()
+	if stillWatched {
+		t.Errorf("watchedDirs[%q] = %d after RemovePattern, want the entry to be gone", linkDir, count)
+	}
+}
+
+// A failed initial expansion must not leave the pattern registered, because
+// nothing would be watching it.
+func TestAddPattern_RollsBackWhenExpansionFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory read permissions are not enforced the same way on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory read permissions")
+	}
+
+	ctx, cancel := donegroup.WithCancel(context.Background())
+	defer cancel()
+
+	s := NewState(ctx)
+
+	base := filepath.Join(t.TempDir(), "unreadable")
+	if err := os.Mkdir(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Searchable but not readable, so os.Stat succeeds while os.ReadDir fails.
+	if err := os.Chmod(base, 0o300); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Chmod(base, 0o755) //nolint:errcheck,gosec // best-effort so TempDir cleanup can proceed
+	})
+
+	pattern := filepath.Join(base, "**", "*.md")
+	if _, err := s.AddPattern(pattern, "scratch"); err == nil {
+		t.Fatal("AddPattern returned no error for an unreadable base directory")
+	}
+
+	if got := s.Patterns(); len(got) != 0 {
+		t.Errorf("Patterns() = %d entries, want 0", len(got))
+	}
+	for _, g := range s.Groups() {
+		if g.Name == "scratch" {
+			t.Error(`group "scratch" was left behind by the failed AddPattern`)
+		}
+	}
+}
+
+func TestFileWatchRefCount(t *testing.T) {
+	t.Run("aliases of one target share a single watch", func(t *testing.T) {
+		s := newTestState(t)
+		canonical := filepath.FromSlash("/canonical/note.md")
+		aliasA := filepath.FromSlash("/alias-a/note.md")
+		aliasB := filepath.FromSlash("/alias-b/note.md")
+
+		s.mu.Lock()
+		s.addFileWatch(aliasA, canonical)
+		s.addFileWatch(aliasB, canonical)
+		got := s.fileWatchTargets[canonical]
+		aliases := len(s.pathAliases[canonical])
+		s.mu.Unlock()
+
+		if got != 2 {
+			t.Errorf("fileWatchTargets[%q] = %d, want 2", canonical, got)
+		}
+		if aliases != 2 {
+			t.Errorf("pathAliases[%q] has %d aliases, want 2", canonical, aliases)
+		}
+
+		// Dropping one alias must keep the target watched for the other.
+		s.mu.Lock()
+		s.removeFileWatch(aliasA)
+		got = s.fileWatchTargets[canonical]
+		_, aliasBStillMapped := s.aliasReverse[aliasB]
+		s.mu.Unlock()
+
+		if got != 1 {
+			t.Errorf("fileWatchTargets[%q] = %d after removing one alias, want 1", canonical, got)
+		}
+		if !aliasBStillMapped {
+			t.Errorf("aliasReverse lost %q while it was still watched", aliasB)
+		}
+
+		s.mu.Lock()
+		s.removeFileWatch(aliasB)
+		_, targetExists := s.fileWatchTargets[canonical]
+		_, canonicalExists := s.pathAliases[canonical]
+		s.mu.Unlock()
+
+		if targetExists {
+			t.Errorf("fileWatchTargets[%q] should be gone once every alias was removed", canonical)
+		}
+		if canonicalExists {
+			t.Errorf("pathAliases[%q] should be gone once every alias was removed", canonical)
+		}
+	})
+
+	t.Run("one path held by several groups is released once", func(t *testing.T) {
+		s := newTestState(t)
+		path := filepath.FromSlash("/plain/note.md")
+
+		s.mu.Lock()
+		s.addFileWatch(path, "")
+		s.addFileWatch(path, "")
+		s.removeFileWatch(path)
+		count := s.watchedFiles[path]
+		s.mu.Unlock()
+
+		if count != 1 {
+			t.Fatalf("watchedFiles[%q] = %d, want 1", path, count)
+		}
+
+		s.mu.Lock()
+		s.removeFileWatch(path)
+		_, exists := s.watchedFiles[path]
+		s.mu.Unlock()
+
+		if exists {
+			t.Errorf("watchedFiles[%q] should be gone at zero", path)
+		}
+	})
+
+	t.Run("no-op for unknown path", func(t *testing.T) {
+		s := newTestState(t)
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.removeFileWatch(filepath.FromSlash("/unknown/note.md"))
+	})
+}
+
+func TestRemoveDirWatch_SharedTarget(t *testing.T) {
+	s := newTestState(t)
+	canonical := filepath.FromSlash("/canonical/dir")
+	aliasA := filepath.FromSlash("/alias-a/dir")
+	aliasB := filepath.FromSlash("/alias-b/dir")
+
+	s.mu.Lock()
+	s.watchedDirs[aliasA] = 1
+	s.watchedDirs[aliasB] = 1
+	s.watchTargets[canonical] = 2
+	s.registerPathAlias(aliasA, canonical)
+	s.registerPathAlias(aliasB, canonical)
+	s.mu.Unlock()
+
+	s.removeDirWatch(aliasA)
+
+	s.mu.RLock()
+	got := s.watchTargets[canonical]
+	_, aliasBStillMapped := s.aliasReverse[aliasB]
+	s.mu.RUnlock()
+
+	if got != 1 {
+		t.Errorf("watchTargets[%q] = %d after removing one alias, want 1", canonical, got)
+	}
+	if !aliasBStillMapped {
+		t.Errorf("aliasReverse lost %q while it was still watched", aliasB)
+	}
+
+	s.removeDirWatch(aliasB)
+
+	s.mu.RLock()
+	_, targetExists := s.watchTargets[canonical]
+	_, canonicalExists := s.pathAliases[canonical]
+	s.mu.RUnlock()
+
+	if targetExists {
+		t.Errorf("watchTargets[%q] should be gone once every alias was removed", canonical)
+	}
+	if canonicalExists {
+		t.Errorf("pathAliases[%q] should be gone once every alias was removed", canonical)
+	}
+}
+
+// unregisterPathAlias must keep the canonical entry while other aliases of the
+// same target remain registered.
+func TestUnregisterPathAlias_KeepsCanonicalWhileAliasesRemain(t *testing.T) {
+	s := newTestState(t)
+	canonical := filepath.FromSlash("/canonical/dir")
+	aliasA := filepath.FromSlash("/alias-a/dir")
+	aliasB := filepath.FromSlash("/alias-b/dir")
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.registerPathAlias(aliasA, canonical)
+	s.registerPathAlias(aliasB, canonical)
+
+	s.unregisterPathAlias(aliasA)
+
+	if _, ok := s.pathAliases[canonical][aliasB]; !ok {
+		t.Errorf("pathAliases[%q] lost %q", canonical, aliasB)
+	}
+	if _, ok := s.pathAliases[canonical][aliasA]; ok {
+		t.Errorf("pathAliases[%q] still contains %q", canonical, aliasA)
+	}
+	if _, ok := s.aliasReverse[aliasA]; ok {
+		t.Errorf("aliasReverse still contains %q", aliasA)
+	}
+
+	s.unregisterPathAlias(aliasB)
+
+	if _, ok := s.pathAliases[canonical]; ok {
+		t.Errorf("pathAliases[%q] should be gone once every alias was removed", canonical)
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2970,3 +2970,46 @@ func TestUnregisterPathAlias_KeepsCanonicalWhileAliasesRemain(t *testing.T) {
 		t.Errorf("pathAliases[%q] should be gone once every alias was removed", canonical)
 	}
 }
+
+// Only unresolvable entries that are already tracked as watched directories
+// may reach the directory-watch bookkeeping. A dangling file symlink is
+// unresolvable but was never a watched directory, so it must be skipped.
+func TestWalkDirsForPattern_SkipsUnresolvableNonDirEntries(t *testing.T) {
+	ctx, cancel := donegroup.WithCancel(context.Background())
+	defer cancel()
+
+	s := NewState(ctx)
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dangling := filepath.Join(dir, "dangling.md")
+	if err := os.Symlink(filepath.Join(dir, "missing.md"), dangling); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	pattern := filepath.Join(dir, "**", "*.md")
+	if _, err := s.AddPattern(pattern, DefaultGroup); err != nil {
+		t.Fatalf("AddPattern returned error: %v", err)
+	}
+	patterns := s.Patterns()
+	if len(patterns) != 1 {
+		t.Fatalf("Patterns() = %d entries, want 1", len(patterns))
+	}
+
+	var visited []string
+	s.walkDirsForPattern(patterns[0], func(p string) {
+		visited = append(visited, p)
+	})
+
+	if slices.Contains(visited, dangling) {
+		t.Errorf("walkDirsForPattern handed over %q, which is not a watched directory", dangling)
+	}
+	for _, want := range []string{dir, sub} {
+		if !slices.Contains(visited, want) {
+			t.Errorf("walkDirsForPattern did not hand over %q; visited=%q", want, visited)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #275. Recursive symlink support left three bookkeeping gaps, each of which only surfaces once a directory or file is reachable through more than one path.

`walkDirsForPattern` lost the best-effort behaviour the previous `filepath.WalkDir` callback had, which called `fn(path)` for a failing path specifically so that unwatch could still decrement its refcount. `walkSymlinkTree` only logged child errors and never handed those paths to `visitDir`, and the `!visitedBase` guard covered the root alone. A directory symlink that resolved when the watch was set up but dangles by the time the pattern is removed was therefore skipped: its refcount never reached zero, the watch on the canonical target was never released, and `isWatchedDir` kept returning true so later Remove/Rename events still routed into `handleDirMove` for the stale entry. `walkSymlinkTree` now returns the paths it could not classify, arranged so that a path already handed to `visitDir` is never reported twice and thus never decremented twice.

`AddPattern` appends the pattern to `s.patterns` before running its initial expansion, so the `glob expansion failed` return left behind a pattern that nothing watches. That return used to be effectively unreachable because `doublestar.Glob` swallows IO errors unless `WithFailOnIOErrors` is set, but `walkSymlinkTree` propagates `EvalSymlinks` and `ReadDir` errors for the base directory. A base that stats fine yet cannot be read now hands an error to the caller while the pattern stays in state, is persisted to the backup file and reported by `/_/api/status`, and a later `RemovePattern` walks the tree decrementing refcounts it never incremented, which can release a watch another pattern still needs. The registration is rolled back instead.

File watches had no equivalent of the `watchedDirs` / `watchTargets` split that #275 introduced for directories, even though `AddFile` started registering an alias on `ErrAlreadyAdded` and so already acknowledged that two user-facing paths can share one physical watch. `RemoveFile` decided by exact path equality and then removed the watch, so dropping one alias of a file reachable through several symlink paths tore down the watch the remaining aliases still relied on. `addFileWatch` and `removeFileWatch` now mirror the directory pair exactly, counting logical paths and the physical target separately, which also subsumes the old `stillReferenced` scan.

One point is settled deliberately rather than changed: alias paths stay distinct `FileEntry` values instead of being collapsed onto their canonical form. `FileID` is derived from the path, so collapsing would make the surviving ID depend on directory read order and destabilise deep links and session restore, and preferring the canonical form would move an entry outside the tree the user asked to watch. The reasoning now sits next to the expansion so it is not read as an oversight later.

Deliberately out of scope: the `WithFilesOnly` behaviour difference between `dir/*.md` and `dir/**/*.md`, the re-watch call in `watchLoop` that adds an event path outside the refcount, and disambiguating identical file names in the flat sidebar.