### PR TITLE
ci: report the coverage of a pull request as well

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -26,6 +26,5 @@ comment:
 summary:
   if: true
 report:
-  if: is_default_branch
   datastores:
     - artifact://${GITHUB_REPOSITORY}


### PR DESCRIPTION
## Summary

`report.if: is_default_branch` means a pull request measures its coverage, comments it, and then throws the report away. Nothing is stored, so the coverage of a pull request cannot be looked at once the run is over.

The condition had a reason. The artifact datastore held one report per repository key, so a run on any ref other than `main` stored under the same `octocov-report` name and overwrote the report that `diff.datastores:` compares against — the next pull request would then be diffed against another pull request rather than against `main`.

[k1LoW/octocov#720](https://github.com/k1LoW/octocov/pull/720), released in [v0.77.0](https://github.com/k1LoW/octocov/releases/tag/v0.77.0), derives the artifact name from the ref: a pull request stores under `octocov-report@refs_pull_N`, a branch under `octocov-report@refs_heads_<name>`, and the default branch keeps the bare `octocov-report` that `diff.datastores:` reads. The overwrite the condition guarded against can no longer happen, and [#721](https://github.com/k1LoW/octocov/pull/721) dropped the same line from the config octocov generates for a new repository.

So the line goes. Every run stores its report from now on, while the comparison shown in the pull request comment is unchanged.

### Notes

**`.github/workflows/ci.yml` is untouched, deliberately.** `octocov-action`'s `version:` input defaults to `latest`, so v0.77.0 is already in use and the pinned action SHA does not hold octocov back. The octocov step is confined to the Linux leg of the matrix, so a run still stores exactly once. That last part matters: octocov's own repository gates a second octocov step on the event name, because storing the report twice within one run makes octocov delete the artifact it wrote first, and that delete needs the `actions: write` a fork's token does not have. mo stores once per run, so it never reaches that delete — which is worth stating here, since a good share of the pull requests to this repository come from forks.

**`.octocov.yml` is the only octocov config in the tree**, and `build` is the only workflow that invokes octocov, so nothing else carries the same condition.